### PR TITLE
Fix Virtual-DOM usage and support hiding children from virtual-dom

### DIFF
--- a/src/Previewer.js
+++ b/src/Previewer.js
@@ -416,7 +416,7 @@ export default class Previewer {
       return vDH('span', {}, []);
     }
     if (!dom.tagName) {
-      return dom.wholeText;
+      return dom.textContent;
     }
     const { tagName } = dom;
     const myAttrs = this.$getAttrsForH(dom.attributes);

--- a/src/Previewer.js
+++ b/src/Previewer.js
@@ -419,9 +419,13 @@ export default class Previewer {
       return dom.textContent;
     }
     const { tagName } = dom;
+
+    // skip all children if data-cm-atomic attribute is set
+    const isAtomic = 'true' === dom.getAttribute('data-cm-atomic');
+
     const myAttrs = this.$getAttrsForH(dom.attributes);
     const children = [];
-    if (dom.childNodes && dom.childNodes.length > 0) {
+    if (!isAtomic && dom.childNodes && dom.childNodes.length > 0) {
       for (let i = 0; i < dom.childNodes.length; i++) {
         children.push(this.$html2H(dom.childNodes[i]));
       }

--- a/src/Previewer.js
+++ b/src/Previewer.js
@@ -469,7 +469,7 @@ export default class Previewer {
       }
     }
     if (ret.style) {
-      ret.style = ret.style.join(';');
+      ret.style = { cssText: ret.style.join(';') }; // see virtual-dom implementation
     }
     return ret;
   }


### PR DESCRIPTION
**Describe the bug**

I'm implementing a plugin that render something extra into the previewer. User may write `%%specialSyntax%%` and it turns into a `div` placeholder. An async process will load data and replace the placeholder.

However in the editor, when the previewer updates, the rendered content will be totally removed.

I noticed that CherryMarkdown take **current actual HTML as snapshot and build a virtual dom tree**, then compare it with a **virtual dom tree from temp document fragment**. Due to the async-mounting strategy, it is **impossible** to avoid removing my content 😢 

Therefore in this PR:

- fix some werid virtual-dom usage
- support `data-cm-atomic` attribute in the rendered HTML. which will ignore all children of current Node so that all async-mounted things will be preserved :)

close #286 