### PR TITLE
完善inlinecode hook，新增通过两个commonmark范例

### DIFF
--- a/src/core/hooks/CodeBlock.js
+++ b/src/core/hooks/CodeBlock.js
@@ -307,7 +307,7 @@ export default class CodeBlock extends ParagraphBase {
     });
     // 为了避免InlineCode被HtmlBlock转义，需要在这里提前缓存
     // InlineBlock只需要在afterMakeHtml还原即可
-    const INLINE_CODE_REGEX = /(`+)(.+?(?:\n.+?)*?)\1/g;
+    const INLINE_CODE_REGEX = /(`+)(.+?(?:`?)(?:\n.+?)*?)\1/g;
     if (INLINE_CODE_REGEX.test($str)) {
       $str = $str.replace(/\\`/g, '~~not~inlineCode');
       $str = $str.replace(INLINE_CODE_REGEX, (match, syntax, code) => {

--- a/src/core/hooks/InlineCode.js
+++ b/src/core/hooks/InlineCode.js
@@ -38,7 +38,7 @@ export default class InlineCode extends ParagraphBase {
   }
 
   rule() {
-    const ret = { begin: '(`+)[ ]*', end: '[ ]*\\1', content: '(.+?(?:\\n.+?)*?)' };
+    const ret = { begin: '(`+)[ ]*', end: '[ ]*\\1', content: '(.+?（?:`?)(?:\\n.+?)*?)' };
     ret.reg = compileRegExp(ret, 'g');
     return ret;
   }


### PR DESCRIPTION
在修改正则的时候我发现修改inlinecode.js文件的正则表达式是没有用的，必须修改CodeBlock.js内INLINE_CODE_REGEX正则表达式才能改变正则匹配模式。