### PR TITLE
fix(Previewer): 调整暗黑模式下高亮行颜色

### DIFF
--- a/src/sass/themes/dark.scss
+++ b/src/sass/themes/dark.scss
@@ -380,4 +380,8 @@ $mdSvgTextColor: rgb(250, 160, 0);
     }
   }
 
+  .cherry-highlight-line {
+    background-color: #151422;
+  }
+
 }


### PR DESCRIPTION
原有的默认高亮在暗黑模式下会使预览框内的文字难以阅读。
![image](https://github.com/Tencent/cherry-markdown/assets/11886705/935c7d44-e647-411f-90fe-f2e803c7a976)

修改后：
![image](https://github.com/Tencent/cherry-markdown/assets/11886705/2ceaa2eb-e6c5-4eb0-9af9-b3f138bbcb3e)
