### PR TITLE
添加了一个onMouseDown函数,使得工具栏的子窗口在点击预览界面时也能被消除

### DIFF
--- a/src/Previewer.js
+++ b/src/Previewer.js
@@ -131,6 +131,7 @@ export default class Previewer {
     this.$initPreviewerBubble();
     this.lazyLoadImg = new LazyLoadImg(this.options.lazyLoadImg, this);
     this.lazyLoadImg.doLazyLoad();
+    this.onMouseDown();
   }
 
   $initPreviewerBubble() {
@@ -904,6 +905,13 @@ export default class Previewer {
     this.$scrollAnimation(top);
   }
 
+  onMouseDown() {
+    addEvent(this.getDomContainer(), 'mousedown', () => {
+      setTimeout(() => {
+        Event.emit(this.instanceId, Event.Events.cleanAllSubMenus);
+      });
+    });
+  }
   /**
    * 导出预览区域内容
    * @public


### PR DESCRIPTION
网页版的工具栏的子窗口被点开之后，只能通过在编辑区（Editor）部分点击页面来消除，在预览区（Previewer）点击无法消除；在纯预览模式下，工具栏的子窗口被点开之后不能通过点击页面来消除。

因此在Previewer.js中仿照Editor.js中的相关内容增加了一个onMouseDown函数,使其监听预览区的鼠标点击事件，令工具栏的子窗口在点击预览界面时也能被消除