### PR TITLE
fix(Unittest): 修复了单元测试代码中的诸多小问题

### DIFF
--- a/test/core/CommonMark.spec.ts
+++ b/test/core/CommonMark.spec.ts
@@ -22,6 +22,8 @@ const cleanHTML = (raw) => {
   html = html.replace(/(?<=>)\n(?=<)/gm, '');
   // 清理属性
   html = html.replace(/(?<=<)([^\/\s>]+)[^<]*?(?=>)/gm, (match, tag) => tag);
+  // 清理首尾的多余空格
+  html = html.trim();
   return html;
 }
 

--- a/test/core/CommonMark.spec.ts
+++ b/test/core/CommonMark.spec.ts
@@ -18,6 +18,7 @@ const cherryEngine = new CherryEngine({
 const cleanHTML = (raw) => {
   // 处理换行回车
   let html = raw.replace(/\s*<br>\s*/gm, '\n');
+  html = html.replace(/\s*<br \/>\s*/gm, '\n');
   html = html.replace(/(?<=>)\n(?=<)/gm, '');
   // 清理属性
   html = html.replace(/(?<=<)([^\/\s>]+)[^<]*?(?=>)/gm, (match, tag) => tag);

--- a/test/core/CommonMark.spec.ts
+++ b/test/core/CommonMark.spec.ts
@@ -31,6 +31,8 @@ const formatOutput = (message, input, standard, result) => {
     input: ${input}
     standard: ${standard}
     cherry: ${result}
+    standard(cleaned): ${cleanHTML(standard)}
+    cherry(cleaned): ${cleanHTML(result)}
   `
 }
 

--- a/test/core/CommonMark.spec.ts
+++ b/test/core/CommonMark.spec.ts
@@ -48,7 +48,7 @@ expect.extend({
 
 describe('engine', () => {
   suites.forEach((item, index) => {
-    test(`commonmark-${index}`, () => {
+    test(`commonmark-${item.example}`, () => {
     // @ts-ignore
       expect(cherryEngine.makeHtml(item.markdown)).matchHTML(item.html, item.markdown);
     });


### PR DESCRIPTION
修复了单元测试代码中的诸多小问题，包括：
- 修正了运行单元测试时，测试点 id 与 commonmark.spec.json 对不上的问题
- 在 test/core/CommonMark.spec.ts 中加入对 <br /> 的处理
- 在 test/core/CommonMark.spec.ts 添加了清理后的 HTML 的输出
- 在 test/core/CommonMark.spec.ts 中加入对字符串首尾的空格的处理

改正这些问题后，通过的测试点数目从 172 上升到了 194。