### PR TITLE
fix(Previewer): 修复html2canvas导致的含MathJax的截图导出重影问题

### DIFF
--- a/src/utils/export.js
+++ b/src/utils/export.js
@@ -47,6 +47,11 @@ const undoHideBodyChildren = (displayList = []) => {
  */
 const getReadyToExport = (previeweDom, cb) => {
   const cherryPreviewer = /** @type {HTMLElement}*/ (previeweDom.cloneNode(true));
+  const mmls = cherryPreviewer.querySelectorAll('mjx-assistive-mml');
+  // a fix for html2canvas
+  mmls.forEach((e) => {
+    if (e instanceof HTMLElement) e.style.setProperty('visibility', 'hidden');
+  });
   const cherryWrapper = document.createElement('div');
   cherryWrapper.appendChild(cherryPreviewer);
   const displayList = hideBodyChildren();


### PR DESCRIPTION
https://github.com/niklasvh/html2canvas/issues/2945
上述库的bug导致了使用该库的截图导出功能出现了相同的问题。
通过在预览区预处理过程中调整所有`mjx-assistive-mml`元素的`visibility`属性以修复此问题。