### PR TITLE
feat(Editor): 增加对罗马数字与汉字列表的换行自动补全

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -40,6 +40,7 @@ import Event from '@/Event';
 import { handelParams } from '@/utils/file';
 import { createElement } from './utils/dom';
 import { imgBase64Reg, imgDrawioXmlReg } from './utils/regexp';
+import { handleNewlineIndentList } from './utils/autoindent';
 
 /**
  * @typedef {import('~types/editor').EditorConfiguration} EditorConfiguration
@@ -79,7 +80,9 @@ export default class Editor {
         autofocus: true,
         theme: 'default',
         autoCloseTags: true, // 输入html标签时自动补充闭合标签
-        extraKeys: { Enter: 'newlineAndIndentContinueMarkdownList' }, // 增加markdown回车自动补全
+        extraKeys: {
+          Enter: handleNewlineIndentList,
+        }, // 增加markdown回车自动补全
         matchTags: { bothTags: true }, // 自动高亮选中的闭合html标签
         placeholder: '',
         // 设置为 contenteditable 对输入法定位更友好

--- a/src/core/hooks/Suggester.js
+++ b/src/core/hooks/Suggester.js
@@ -198,7 +198,7 @@ class SuggesterPanel {
               return res;
             }
             // logic to decide whether to move up or not
-            return Pass.toString();
+            // return Pass.toString();
           }
         };
       } else if (!extraKeys[key]) {

--- a/src/utils/autoindent.js
+++ b/src/utils/autoindent.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param {CodeMirror.Editor} cm
+ */
+export function handleNewlineIndentList(cm) {
+  if (handleCherryList(cm)) return;
+  cm.execCommand('newlineAndIndentContinueMarkdownList');
+}
+
+function handleCherryList(cm) {
+  const cherryListRE = /^(\s*)([I一二三四五六七八九十]+)\.(\s+)/;
+  const cherryListEmptyRE = /^(\s*)([I一二三四五六七八九十]+)\.(\s+)$/;
+  if (cm.getOption('disableInput')) return false;
+  const ranges = cm.listSelections();
+  const replacements = [];
+  for (let i = 0; i < ranges.length; i++) {
+    const pos = ranges[i].head;
+    const line = cm.getLine(pos.line);
+    const match = cherryListRE.exec(line);
+    const cursorBeforeBullet = /^\s*$/.test(line.slice(0, pos.ch));
+    if (!ranges[i].empty() || cursorBeforeBullet || !match) return;
+    if (cherryListEmptyRE.test(line)) {
+      cm.replaceRange(
+        '',
+        {
+          line: pos.line,
+          ch: 0,
+        },
+        {
+          line: pos.line,
+          ch: pos.ch + 1,
+        },
+      );
+      replacements[i] = '\n';
+    } else {
+      const indent = match[1];
+      const after = match[3];
+      replacements[i] = `\n${indent}I.${after}`;
+    }
+  }
+  cm.replaceSelections(replacements);
+  return true;
+}


### PR DESCRIPTION
尝试着仿照Codemirror内部对Markdown列表换行补全的实现写了一个作用与罗马数字和汉字列表的类似的实现（但是巧妙利用了列表渲染系统的特性，实现效果可能并不是特别优美）

经简单测试不会影响换行的原有功能。

同时由于不知道增加的新函数放哪所以新开了一个文件，代码结构如有不妥麻烦reviewer提出调整意见。