### PR TITLE
For cherry-markdown, support Cloud Studio to run examples 

### DIFF
--- a/.vscode/preview.yml
+++ b/.vscode/preview.yml
@@ -1,0 +1,9 @@
+# .vscode/preview.yml
+autoOpen: true # 打开工作空间时是否自动开启所有应用的预览
+apps:
+  - port: 8000 # 应用的端口
+    run: yarn && yarn run dev # 应用的启动命令
+    root: ./ # 应用的启动目录
+    name: Cherry Markdown Editor # 应用名称
+    description: Cherry Markdown Editor # 应用描述
+    autoOpen: true # 打开工作空间时是否自动开启预览（优先级高于根级 autoOpen）

--- a/README.CN.md
+++ b/README.CN.md
@@ -1,6 +1,7 @@
 <p align="center"><img src="logo/logo--color.svg" alt="cherry logo" width="50%"/></p>
 
 # Cherry Markdown Editor
+[![Cloud Studio Template](https://cs-res.codehub.cn/common/assets/icon-badge.svg)](https://cloudstudio.net#https://github.com/Tencent/cherry-markdown)
 
 ## 介绍
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center"><img src="logo/new_logo.png" alt="cherry logo" width="50%"/></p>
 
 # Cherry Markdown Writer
+[![Cloud Studio Template](https://cs-res.codehub.cn/common/assets/icon-badge.svg)](https://cloudstudio.net#https://github.com/Tencent/cherry-markdown)
 
 English | [简体中文](./README.CN.md)
 

--- a/build/dev.js
+++ b/build/dev.js
@@ -46,6 +46,13 @@ if (process.env.CODESPACES === 'true') {
   process.env.CODESANDBOX_SSE = 'true';
 }
 
+// Using Tencent Cloud Studio is always 'TRUE' for Cloud Development Environment (X_IDE_IS_CLOUDSTUDIO=TRUE)
+if (process.env.X_IDE_IS_CLOUDSTUDIO === 'TRUE') {
+  // a hack for rollup-plugin-livereload's websocket connection
+  process.env.CODESANDBOX_SSE = 'true';
+}
+
+
 if (enableHotReload) {
   options.plugins = options.plugins.concat([
     serve({


### PR DESCRIPTION
1. Add Cloud Studio cloud development env for cherry-markdown project. (https://cloudstudio.net/cde)
2. Add a preview.yaml for automation run script then after started, user can see the example on the right hand side.
3. Add a port forward for Cloud Studio env (X_IDE_IS_CLOUDSTUDIO)