### PR TITLE
fix issue #558

### DIFF
--- a/src/core/hooks/Suggester.js
+++ b/src/core/hooks/Suggester.js
@@ -650,6 +650,14 @@ class SuggesterPanel {
     const { keyCode } = evt;
     // up down
     if ([38, 40].includes(keyCode)) {
+      // issue 558
+      if (this.optionList.length === 0) {
+        setTimeout(() => {
+          this.stopRelate();
+        }, 0);
+        return;
+      }
+
       this.cursorMove = false;
 
       const selectedItem = this.$suggesterPanel.querySelector('.cherry-suggester-panel__item--selected');


### PR DESCRIPTION
修复了输入联想无选项时上下键失效的问题
现在无选项时使用上下键会正常移动光标并停止联想