### PR TITLE
fix: #560 toolbar合并hooks时，重名的处理方式改为保留toolbar原有hook

### DIFF
--- a/src/toolbars/Toolbar.js
+++ b/src/toolbars/Toolbar.js
@@ -205,7 +205,7 @@ export default class Toolbar {
    */
   collectMenuInfo(toolbarObj) {
     this.toolbarHandlers = Object.assign({}, this.toolbarHandlers, toolbarObj.toolbarHandlers);
-    this.menus.hooks = Object.assign({}, this.menus.hooks, toolbarObj.menus.hooks);
+    this.menus.hooks = Object.assign({}, toolbarObj.menus.hooks, this.menus.hooks);
     // 只有没设置自定义快捷键的时候才需要收集其他toolbar对象的快捷键配置
     if (!this.options.shortcutKey || Object.keys(this.options.shortcutKey).length <= 0) {
       this.shortcutKeyMap = Object.assign({}, this.shortcutKeyMap, toolbarObj.shortcutKeyMap);


### PR DESCRIPTION
测试的结论是api并不需要收集hooks，可以直接删掉，但也影响有限，就只改了重名覆盖方式，保留收集hooks过程