### PR TITLE
fix: 在ctrl+a全选时不能展示SuggesterPanel，但会进入Suggester状态

### DIFF
--- a/src/core/hooks/Suggester.js
+++ b/src/core/hooks/Suggester.js
@@ -504,7 +504,12 @@ class SuggesterPanel {
 
   // 面板重定位
   relocatePanel(codemirror) {
-    const $cursor = document.querySelector('.CodeMirror-cursors .CodeMirror-cursor');
+    // 找到光标位置来确定候选框位置
+    let $cursor = document.querySelector('.CodeMirror-cursors .CodeMirror-cursor');
+    // 当editor选中某一内容时，".CodeMirror-cursor"会消失，此时通过定位".selected"来确定候选框位置
+    if (!$cursor) {
+      $cursor = document.querySelector('.CodeMirror-selected');
+    }
     if (!$cursor) {
       return false;
     }


### PR DESCRIPTION
#583 
bug原因：
在生成候选框时是用document.querySelector('.CodeMirror-cursors .CodeMirror-cursor');来定位光标位置，但是当editor处于选中任意内容时，'.CodeMirror-cursors'就没有子元素'.CodeMirror-cursor'，因此代码无法正常showsuggesterPanel。
解决方案：
在判断没有子元素'.CodeMirror-cursor'时，通过定位选中框'.CodeMirror-selected'来定位候选框，此时便可以正常showsuggesterPanel。