### PR TITLE
fix: 修复formatFullWidthMark函数

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: prerequisites
     attributes:
       label: Prerequisites
-      description: Before submitting the issue, ensure the following:
+      description: 'Before submitting the issue, ensure the following:'
       options:
         - label: There isn't an existing issue that reports the same bug to avoid duplicates.
         - label: The provided information offers a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) of the bug.

--- a/.github/ISSUE_TEMPLATE/client_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/client_feedback.yml
@@ -11,7 +11,7 @@ body:
     id: prerequisites
     attributes:
       label: Prerequisites
-      description: Before submitting the issue, ensure the following:
+      description: 'Before submitting the issue, ensure the following:'
       options:
         - label: There isn't an existing issue that requests the same feature, to avoid duplicates.
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/documentation_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_feedback.yml
@@ -11,7 +11,7 @@ body:
     id: prerequisites
     attributes:
       label: Prerequisites
-      description: Before submitting the issue, ensure the following:
+      description: 'Before submitting the issue, ensure the following:'
       options:
         - label: There isn't an existing issue with the same question or request to avoid duplicates.
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
     id: prerequisites
     attributes:
       label: Prerequisites
-      description: Before submitting the issue, ensure the following:
+      description: 'Before submitting the issue, ensure the following:'
       options:
         - label: There isn't an existing issue that requests the same feature, to avoid duplicates.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/vscode_plugin_report.yml
+++ b/.github/ISSUE_TEMPLATE/vscode_plugin_report.yml
@@ -1,7 +1,7 @@
-name: 🔌 vscodePlugin issue
-description: About vscodePlugin issue
-title: '[vscodePlugin]'
-labels: [vscodePlugin]
+name: 🔌 VSCode Plugin issue
+description: About VSCode Plugin issue
+title: '[VSCode Plugin]'
+labels: [VSCode Plugin]
 body:
   - type: markdown
     attributes:
@@ -11,7 +11,7 @@ body:
     id: type
     attributes:
       label: issue type
-      description: What type of issue is this about vscodePlugin? 
+      description: What type of issue is this about VSCode Plugin? 
       options:
         - Bug
         - Feature

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -169,10 +169,12 @@ export default class Editor {
     let oneSearch = searcher.findNext();
     // 防止出现错误的mark
     editor.getAllMarks().forEach(function (mark) {
-      const range = JSON.parse(JSON.stringify(mark.find()));
-      const markedText = editor.getRange(range.from, range.to);
-      if (mark.className === 'cm-fullWidth' && !regex.test(markedText)) {
-        mark.clear();
+      if (mark.className === 'cm-fullWidth') {
+        const range = JSON.parse(JSON.stringify(mark.find()));
+        const markedText = editor.getRange(range.from, range.to);
+        if (!regex.test(markedText)) {
+          mark.clear();
+        }
       }
     });
     for (; oneSearch !== false; oneSearch = searcher.findNext()) {


### PR DESCRIPTION
此处存在的问题：
`mark.find()`返回的并不一定是一个range，如果用户有自己设置bookmark，那么返回的是一个position，下面的`getRange`函数则会调用失败
报错信息类似
<img width="531" alt="image" src="https://github.com/Tencent/cherry-markdown/assets/48169104/be558964-d14d-495d-9a08-d26f1a02e647">


此处修改的思路：
既然是要判断`mark.className === 'cm-fullWidth'`来确定当前mark是否为自己创建的mark，那么应该提到最上层，先判断这个条件，避免其他人的TextMarker干扰