### PR TITLE
fix: 修复自定义keyword覆盖问题

### DIFF
--- a/src/core/hooks/Suggester.js
+++ b/src/core/hooks/Suggester.js
@@ -131,7 +131,7 @@ export default class Suggester extends SyntaxBase {
     if (!suggester) {
       suggester = defaultSuggest;
     } else {
-      suggester = suggester.concat(defaultSuggest);
+      suggester = defaultSuggest.concat(suggester);
     }
 
     suggester.forEach((configItem) => {
@@ -509,8 +509,6 @@ class SuggesterPanel {
         typeof this.optionList[idx].value === 'function'
       ) {
         result = this.optionList[idx].value();
-      } else if (typeof this.optionList[idx] === 'string') {
-        result = `${this.optionList[idx]} `;
       } else {
         result = ` ${this.keyword}${this.optionList[idx]} `;
       }


### PR DESCRIPTION
1.修复了不能覆盖默认关键字的行为,如自定义’/‘关键字对应suggestlist，会不生效
2.修复@关键字选择后丢失的问题，如@key，选择后会输出key