### PR TITLE
fix: image loading failed in vscode plugin

### DIFF
--- a/vscodePlugin/tsconfig.json
+++ b/vscodePlugin/tsconfig.json
@@ -4,7 +4,8 @@
 		"target": "es6",
 		"outDir": "out",
 		"lib": [
-			"es6"
+			"es6",
+			"DOM"
 		],
 		"sourceMap": true,
 		"rootDir": "src",
@@ -14,6 +15,9 @@
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
 	},
+	"include": [
+		"src/**/*.ts"
+	],
 	"exclude": [
 		"node_modules",
 		".vscode-test"

--- a/vscodePlugin/web-resources/scripts/index.js
+++ b/vscodePlugin/web-resources/scripts/index.js
@@ -1,5 +1,6 @@
 import 'mathjax/es5/tex-svg.js';
 import path from 'path-browserify';
+import vscodeApi from 'vscode';
 // import md5 from 'md5';
 
 /**
@@ -295,15 +296,22 @@ const basicConfig = {
     // eslint-disable-next-line no-undef
     changeString2Pinyin: pinyin,
     beforeImageMounted(srcProp, srcValue) {
+      console.log('beforeImageMounted', srcProp, srcValue);
       if (isHttpUrl(srcValue) || isDataUrl(srcValue)) {
         return {
           src: srcValue,
         };
       }
-      // eslint-disable-next-line no-underscore-dangle
-      const basePath = window._baseResourcePath || '';
+      let imgPath = srcValue;
+      const { workspaceFolders } = vscodeApi.workspace;
+      if (workspaceFolders && workspaceFolders.length > 0) {
+        const workspacePath = workspaceFolders[0].uri.fsPath;
+        imgPath = path.join(workspacePath, srcValue);
+      }
+
       return {
-        src: path.join(basePath, srcValue),
+        // src: path.join(basePath, srcValue),
+        src: imgPath,
       };
     },
   },


### PR DESCRIPTION
fix: ts's `HeadersInit` deletion

close #744