### PR TITLE
feat: add configuration and right-click menu processing preview

### DIFF
--- a/vscodePlugin/package.json
+++ b/vscodePlugin/package.json
@@ -31,9 +31,18 @@
     "commands": [
       {
         "command": "cherrymarkdown.preview",
-        "title": "open cherrymarkdown demo"
+        "title": "Open Cherry Markdown"
       }
     ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "cherrymarkdown.preview",
+          "when": "editorLangId == markdown",
+          "group": "navigation"
+        }
+      ]
+    },
     "icons": {
       "distro-ubuntu": {
         "description": "cherry-markdown icon",
@@ -46,6 +55,15 @@
     "configuration": {
       "title": "cherryMarkdown",
       "properties": {
+        "cherryMarkdown.usage": {
+          "type": "string",
+          "default": "active",
+          "enum": [
+            "active",
+            "only-manual"
+          ],
+          "description": "cherry-markdown's triggering method values: [ active | only-manual ]"
+        },
         "cherryMarkdown.theme": {
           "type": "string",
           "default": "dark",

--- a/vscodePlugin/src/extension.ts
+++ b/vscodePlugin/src/extension.ts
@@ -31,7 +31,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   // 切换文件的时候更新预览区域内容
   vscode.window.onDidChangeActiveTextEditor((e) => {
-    if (e?.document) {
+    const cherryUsage: 'active' | 'only-manual' | undefined = vscode.workspace
+      .getConfiguration('cherryMarkdown')
+      .get('usage');
+
+    if (e?.document && cherryUsage === 'active') {
       triggerEditorContentChange();
       // 如果打开的不是md文件，则让cherry强制进入预览模式
       if (e.document.languageId !== 'markdown' && targetDocument) {


### PR DESCRIPTION
当前可以选择
`active`: 每次触发标签栏的时候触发预览，依然支持右键菜单触发。
`only-manual`: 只支持右键菜单触发。
![1715015223601](https://github.com/Tencent/cherry-markdown/assets/81673017/1fec7ff2-6c37-4357-940f-14216caa0d12)
![1715015203073](https://github.com/Tencent/cherry-markdown/assets/81673017/c1139ab0-158f-4235-bf68-810b7a5e5eed)
