### PR TITLE
fix(vscodePlugin): first open markdown will not activate the extension

### DIFF
--- a/vscodePlugin/package.json
+++ b/vscodePlugin/package.json
@@ -23,7 +23,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:cherrymarkdown.preview"
+    "onLanguage:markdown"
   ],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
背景: 当更新到最新的vscode扩展 `v0.0.15` 时，当我第一次打开vscode，并且使用vscode打开markdown文件的时候，无论`uage`使用哪种方式都不会激活扩展预览，仅当使用右键手动打开`Open Cherry Markdown Preview` 之后，插件预览才能激活。

---
1. 更换了`VS Code 扩展的激活事件(activationEvents)`,当遇到markdown文件即激活扩展。
2. 移除了废弃的扩展激活事件。

close #776

 ![1718430688104](https://github.com/Tencent/cherry-markdown/assets/81673017/c83e103a-5413-448b-abf0-4730f4f87822)