### PR TITLE
style: 优化“淡雅”，“清幽”主题

### DIFF
--- a/src/sass/themes/blue.scss
+++ b/src/sass/themes/blue.scss
@@ -4,21 +4,21 @@
 
 $INDIGO0: #edf2ff;
 $INDIGO1: #dbe4ff;
-$INDIGO2: #bac8ff;
-$INDIGO3: #91a7ff;
+$INDIGO2: #C5CAE9;
+$INDIGO3: #9FA8DA;
 $INDIGO4: #748ffc;
-$INDIGO5: #5c7cfa;
-$INDIGO6: #4c6ef5;
-$INDIGO7: #4263eb;
-$INDIGO8: #3b5bdb;
-$INDIGO9: #364fc7;
+$INDIGO5: #8C9EFF;
+$INDIGO6: #283593; 
+$INDIGO7: #303F9F;
+$INDIGO8: #3949AB;
+$INDIGO9: #283593;
 
-$VIOLET0: #f3f0ff;
-$VIOLET1: #e5dbff;
-$VIOLET2: #d0bfff;
+$VIOLET0: #f3f0ffdc;
+$VIOLET1: #EDE7F6;
+$VIOLET2: #D1C4E9;
 $VIOLET3: #b197fc;
 $VIOLET4: #9775fa;
-$VIOLET5: #845ef7;
+$VIOLET5: #B39DDB;
 $VIOLET6: #7950f2;
 $VIOLET7: #7048e8;
 $VIOLET8: #6741d9;
@@ -31,7 +31,7 @@ $toolbarBtnColor: $INDIGO8;
 $toolbarBtnBgHover: $VIOLET5;
 $toolbarBtnHoverColor: $INDIGO0;
 $toolbarColorItemHoverBorderColor: $INDIGO9;
-$sidebarShadow: 0 0 10px $INDIGO2;
+$sidebarShadow: 0 0 12px $INDIGO2;
 /** 编辑区域样式 */
 $editorBg: $VIOLET0;
 $editorColor: $INDIGO9;
@@ -59,6 +59,7 @@ $mdBlockquoteBg: $VIOLET1;
   .cherry-toolbar, .cherry-floatmenu, .cherry-bubble, .cherry-sidebar {
     background: $toolbarBg;
     border-color: $toolbarBg;
+    box-shadow: $sidebarShadow;
     .cherry-toolbar-button {
       color: $toolbarBtnColor;
       i {


### PR DESCRIPTION
#802 
# 清幽主题

1. 调整整体色调，使视觉风格更加柔和
2. 略微增强阴影效果，提升页面层次感，优化视觉体验

before:
![image](https://github.com/Tencent/cherry-markdown/assets/70378740/022361fe-8817-48db-a841-8ceaf55bc2b0)

after:
![9d0e27c3b5859a004a3ce0b951cecf7c](https://github.com/Tencent/cherry-markdown/assets/70378740/0303cf85-dc02-4a5c-a151-5b902d2f1010)

---

# 淡雅主题

暂未修改