### PR TITLE
feat(ShortcutKey): 增加快捷键配置能力 Closes #571

### DIFF
--- a/src/Factory.js
+++ b/src/Factory.js
@@ -167,6 +167,9 @@ export function createMenuHook(name, options) {
     }
 
     get shortcutKeys() {
+      console.warn(
+        'shortcutKeys will deprecated in the future, please use shortcutKeyMap instead, get more info at https://github.com/Tencent/cherry-markdown/wiki',
+      );
       if (filteredOptions.shortcutKeys) {
         return filteredOptions.shortcutKeys;
       }

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -75,7 +75,7 @@ export default {
   pinyin: 'Pinyin',
   pastePlain: 'Paste as Plain Text',
   pasteMarkdown: 'Paste as Markdown',
-  hide: 'Hide (ctrl+0)',
+  hide: 'Hide Toolbar',
   exportToPdf: 'Export to PDF',
   exportScreenshot: 'Screenshot',
   exportMarkdownFile: 'Export Markdown File',
@@ -99,4 +99,5 @@ export default {
   superLarge: 'Super Large',
   detailDefaultContent:
     'Click to expand more\nContent\n++- Expand by default\nContent\n++ Collapse by default\nContent',
+  editShortcutKeyConfigTip: 'double click shortcut key area to edit',
 };

--- a/src/locales/zh_CN.js
+++ b/src/locales/zh_CN.js
@@ -76,7 +76,7 @@ export default {
   file: '文件',
   pastePlain: '粘贴为纯文本格式', // 粘贴为纯文本格式
   pasteMarkdown: '粘贴为markdown格式', // 粘贴为markdown格式
-  hide: '隐藏(ctrl+0)', // 隐藏(ctrl+0)
+  hide: '隐藏工具栏', // 隐藏
   exportToPdf: '导出PDF', // 导出PDF
   exportScreenshot: '导出长图', // 导出长图
   exportMarkdownFile: '导出markdown', // 导出markdown文件
@@ -102,4 +102,5 @@ export default {
   large: '大',
   superLarge: '特大',
   detailDefaultContent: '点击展开更多\n内容\n++- 默认展开\n内容\n++ 默认收起\n内容',
+  editShortcutKeyConfigTip: '双击快捷键区域编辑快捷键',
 };

--- a/src/sass/cherry.scss
+++ b/src/sass/cherry.scss
@@ -6,6 +6,7 @@
 @import './print.scss';
 @import './bubble_formula.scss';
 @import './formula_utils_bubble.scss';
+@import './components/shortcut_key_config.scss';
 
 @mixin cherryFont {
   font-family: $fontFamily;

--- a/src/sass/components/shortcut_key_config.scss
+++ b/src/sass/components/shortcut_key_config.scss
@@ -1,0 +1,53 @@
+.cherry-shortcut-key-config-panel-wrapper {
+  width: 250px !important;
+  height: 400px !important;
+  .cherry-shortcut-key-config-panel-inner {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    // 隐藏滚动条
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    .shortcut-top {
+      width: 100%;
+    }
+    .cherry-shortcut-key-config-panel-ul {
+      // 去掉列表样式
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+
+      .shortcut-key-item {
+        display: flex;
+        justify-content: space-between;
+        // .shortcut-key-config-panel-name {
+        //   &:hover {
+        //     color: #333;
+        //   }
+        // }
+        .shortcut-key-config-panel-kbd {
+          display: flex;
+          gap: 10px;
+          .keyboard-key {
+            border-radius: 3px;
+            border-style: solid;
+            border-width: 1px;
+            display: inline-block;
+            font-size: 11px;
+            margin: 0 2px;
+            padding: 3px 5px;
+            vertical-align: middle;
+            line-height: 20px;
+            margin: 4px;
+            width: 10px;
+            text-align: center;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/toolbars/ShortcutKeyConfigPanel.js
+++ b/src/toolbars/ShortcutKeyConfigPanel.js
@@ -1,0 +1,233 @@
+import { mac } from 'codemirror/src/util/browser';
+import {
+  getAllowedShortcutKey,
+  keyStackIsModifierkeys,
+  ENTER_KEY,
+  BACKSPACE_KEY,
+  keyStack2UniqueString,
+  shortcutCode2Key,
+  keyStack2UnPlatformUniqueString,
+} from '@/utils/shortcutKey';
+import { createElement } from '@/utils/dom';
+/**
+ * 隐藏输入框，展示快捷键配置项
+ * @param {Element} inputWrapper
+ * @param {HTMLElement} shortcutPanel
+ */
+function hiddenInputWrapper(inputWrapper, shortcutPanel) {
+  inputWrapper.setAttribute('style', 'display: none;');
+  shortcutPanel.style.display = 'flex';
+}
+
+export default class ShortcutKeyConfigPanel {
+  /**
+   *
+   * @param {Partial<import('@/Cherry').default> & {$currentMenuOptions?:import('~types/menus').CustomMenuConfig}} $cherry
+   */
+  constructor($cherry) {
+    this.$cherry = $cherry;
+    this.shortcutUlClassName = 'cherry-shortcut-key-config-panel-ul';
+    this.shortcutUlId = this.shortcutUlClassName;
+    this.shortcutConfigPanelKbdClassName = 'shortcut-key-config-panel-kbd';
+    this.shortcutKeyboardKeyClassName = 'keyboard-key';
+    // 双击快捷键区域
+    this.handleDbClick = (/** @type {MouseEvent} */ e) => {
+      if (e.target instanceof HTMLElement) {
+        if (
+          e.target.classList.contains(this.shortcutConfigPanelKbdClassName) ||
+          e.target.classList.contains(this.shortcutKeyboardKeyClassName)
+        ) {
+          const shortcutPanel = e.target.classList.contains(this.shortcutConfigPanelKbdClassName)
+            ? e.target
+            : e.target.parentElement;
+          // 隐藏展示快捷键的容器
+          shortcutPanel.style.display = 'none';
+          const inputWrapper = shortcutPanel.nextElementSibling;
+          // 显示输入框
+          inputWrapper.setAttribute('style', 'display: block;');
+          const inputElement = inputWrapper.querySelector('input');
+          // 获取焦点
+          inputElement.focus();
+          inputElement.onblur = () => {
+            hiddenInputWrapper(inputWrapper, shortcutPanel);
+            inputElement.value = '';
+          };
+          /** @type {string[]} 按下的快捷键栈 */
+          let keyStack = [];
+          inputElement.onkeydown = (/** @type {KeyboardEvent} */ e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (e.key === ENTER_KEY || e.key === BACKSPACE_KEY) {
+              if (e.key === ENTER_KEY) {
+                const { hookname = '' } = shortcutPanel.parentElement?.dataset ?? {};
+                const oldShortcutKeys = [];
+                for (let i = 0; i < shortcutPanel.children.length; i++) {
+                  /** @type {HTMLDivElement} */
+                  // @ts-ignore
+                  const element = shortcutPanel.children.item(i);
+                  const { code } = element.dataset ?? {};
+                  if (code) {
+                    oldShortcutKeys.push(code);
+                  }
+                }
+                // 防止修改
+                if (oldShortcutKeys.length === shortcutPanel.children.length) {
+                  // 旧的shortcutKey用于在更新时比较，删除旧值
+                  const oldShortcutKey = keyStack2UniqueString(oldShortcutKeys);
+                  if (hookname && this.$cherry?.toolbar?.menus?.hooks?.[hookname]) {
+                    // 触发更新快捷键
+                    this.$cherry?.toolbar?.menus?.hooks?.[hookname].updateShortcutKeyMap(
+                      oldShortcutKey,
+                      keyStack2UniqueString(keyStack),
+                    );
+                    // 取二者较大者
+                    const endIndex = Math.max(keyStack.length, shortcutPanel.children.length);
+                    // 更新界面展示的快捷键
+                    for (let i = 0; i < endIndex; i++) {
+                      const element = shortcutPanel.children.item(i);
+                      // 如果当前快捷键栈不存在了，说明新的快捷键个数比上一次少，则应该删除当前element
+                      if (!keyStack[i] && element) {
+                        element.remove();
+                        continue;
+                      }
+                      const matchRes = shortcutCode2Key(keyStack[i], mac);
+                      if (element) {
+                        element.setAttribute('title', matchRes.tip);
+                        element.textContent = matchRes.text;
+                        element.setAttribute('data-code', keyStack[i]);
+                      } else {
+                        const matchRes = shortcutCode2Key(keyStack[i], mac);
+                        const kbd = createElement('span', this.shortcutKeyboardKeyClassName, {
+                          title: matchRes.tip,
+                        });
+                        kbd.setAttribute('data-code', keyStack[i]);
+                        kbd.innerText = matchRes.text;
+                        shortcutPanel.appendChild(kbd);
+                      }
+                    }
+                  }
+                }
+                hiddenInputWrapper(inputWrapper, shortcutPanel);
+              } else {
+                if (keyStack.length === 0) {
+                  hiddenInputWrapper(inputWrapper, shortcutPanel);
+                }
+                // 退栈
+                keyStack.pop();
+                inputElement.value = keyStack2UnPlatformUniqueString(keyStack, mac);
+              }
+            } else {
+              keyStack = getAllowedShortcutKey(e);
+              if (!keyStackIsModifierkeys(keyStack) && Array.isArray(keyStack) && keyStack.length >= 2) {
+                inputElement.value = keyStack2UnPlatformUniqueString(keyStack, mac);
+              }
+            }
+          };
+        }
+      }
+    };
+    this.init();
+  }
+
+  init() {
+    if (this.$cherry?.toolbar?.shortcutKeyMap) {
+      this.dom = document.createElement('div');
+      this.dom.className = [
+        'cherry-dropdown',
+        'cherry-shortcut-key-config-panel',
+        'cherry-shortcut-key-config-panel-wrapper',
+      ].join(' ');
+      this.dom.innerHTML = this.generateShortcutKeyConfigPanelHtmlStr();
+      // 实例化后，将容器插入到富文本编辑器中，默认隐藏
+      this.dom.style.display = 'none';
+      this.$cherry.wrapperDom.append(this.dom);
+    }
+  }
+
+  generateShortcutKeyConfigPanelHtmlStr() {
+    const liStr = Object.entries(this.$cherry.toolbar.shortcutKeyMap ?? {})
+      .filter(([key, val]) => typeof val === 'object' && val)
+      .map(([key, val]) => {
+        const { hookName, aliasName, ...rest } = val;
+        let otherDataSet = '';
+        if (rest && typeof rest === 'object') {
+          otherDataSet = Object.entries(rest)
+            .map(([otherField, fieldValue]) => `data-${otherField}=${fieldValue}`)
+            .join(' ');
+        }
+        return `<li class="cherry-dropdown-item shortcut-key-item" data-hookname=${hookName} ${otherDataSet}>
+        <div class="shortcut-key-config-panel-name">${aliasName}</div>
+        <div class="${this.shortcutConfigPanelKbdClassName}">${key
+          ?.split('-')
+          .map((singalKey) => {
+            const matchRes = shortcutCode2Key(singalKey, mac);
+            const shortKey = matchRes ?? {
+              text: singalKey,
+              tip: singalKey,
+            };
+            return `<span class="${this.shortcutKeyboardKeyClassName}" title="${shortKey.tip}" data-code="${singalKey}">${shortKey.text}</span>`;
+          })
+          .join('')}</div>
+        <div style="display: none;" class="input-shortcut-wrapper"><input type="text" /></div>
+      </li>`;
+      })
+      .join('');
+    //   <div class="cherry-dropdown-item">
+    //   <input type="checkbox" id="enableMacControl" name="enableMacControl" checked />
+    //   <label for="enableMacControl">启用Mac平台的Control键</label>
+    // </div>
+    const ulStr = `
+      <div class="cherry-shortcut-key-config-panel-inner">
+        <div class="cherry-dropdown-item">${this.$cherry.locale.editShortcutKeyConfigTip}</div>
+        <ul class="${this.shortcutUlClassName}" id="${this.shortcutUlId}">${liStr}</ul>
+      </div>`;
+    return ulStr;
+  }
+
+  /**
+   * 显示快捷键配置面板
+   */
+  show() {
+    this.dom.style.removeProperty('display');
+    const ulWrapper = document.querySelector(`#${this.shortcutUlId}`);
+    if (ulWrapper instanceof HTMLUListElement) {
+      // 监听双击
+      ulWrapper.addEventListener('dblclick', this.handleDbClick);
+    }
+  }
+
+  hide() {
+    this.dom.style.display = 'none';
+    const ulWrapper = document.querySelector(`#${this.shortcutUlId}`);
+    if (ulWrapper instanceof HTMLUListElement) {
+      // 销毁时取消监听
+      ulWrapper.removeEventListener('dblclick', this.handleDbClick);
+    }
+  }
+
+  isShow() {
+    return this.dom.style.display === 'block';
+  }
+
+  isHide() {
+    return this.dom.style.display === 'none';
+  }
+
+  /**
+   * 展示/隐藏快捷键配置面板
+   * @param {HTMLElement} settingsDom
+   */
+  toggle(settingsDom) {
+    if (!(settingsDom instanceof HTMLElement)) {
+      throw new Error(`settingsDom must be an instance of HTMLElement, but got: ${settingsDom}`);
+    }
+    const pos = settingsDom.getBoundingClientRect();
+    if (this.isHide()) {
+      this.dom.style.left = `${pos.left + pos.width}px`;
+      this.dom.style.top = `${pos.top + pos.height}px`;
+      this.show();
+      return;
+    }
+    return this.hide();
+  }
+}

--- a/src/toolbars/hooks/Bold.js
+++ b/src/toolbars/hooks/Bold.js
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 import MenuBase from '@/toolbars/MenuBase';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
 /**
  * 加粗按钮
  */
 export default class Bold extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('bold', 'bold');
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode('b')}`]: {
+        hookName: this.name,
+        aliasName: $cherry.locale[this.name],
+      },
+    };
   }
 
   /**
@@ -59,12 +69,5 @@ export default class Bold extends MenuBase {
       this.setLessSelection('**', '**');
     });
     return $selection.replace(/(^)([^\n]+)($)/gm, '$1**$2**$3');
-  }
-
-  /**
-   * 声明绑定的快捷键，快捷键触发onClick
-   */
-  get shortcutKeys() {
-    return ['Ctrl-b'];
   }
 }

--- a/src/toolbars/hooks/Code.js
+++ b/src/toolbars/hooks/Code.js
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 import MenuBase from '@/toolbars/MenuBase';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
 /**
  * 插入代码块的按钮
  */
 export default class Code extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('code', 'code');
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode('k')}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale[this.name],
+      },
+    };
   }
 
   /**
@@ -35,12 +45,5 @@ export default class Code extends MenuBase {
       this.setLessSelection(`\n\`\`\` \n`, `\n\`\`\`\n`);
     });
     return `\n\`\`\` \n${code}\n\`\`\`\n`;
-  }
-
-  /**
-   * 声明绑定的快捷键，快捷键触发onClick
-   */
-  get shortcutKeys() {
-    return ['Ctrl-k'];
   }
 }

--- a/src/toolbars/hooks/Formula.js
+++ b/src/toolbars/hooks/Formula.js
@@ -15,17 +15,28 @@
  */
 import MenuBase from '@/toolbars/MenuBase';
 import BubbleFormula from '../BubbleFormula';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
+
 /**
  * 插入行内公式
  * @see https://github.com/QianJianTech/LaTeXLive/blob/master/README.md
  */
 export default class Formula extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('formula', 'insertFormula');
     this.subBubbleFormulaMenu = new BubbleFormula($cherry?.options?.toolbars?.config?.formula);
     $cherry.editor.options.wrapperDom.appendChild(this.subBubbleFormulaMenu.dom);
     this.catchOnce = '';
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode('m')}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale[this.name],
+      },
+    };
   }
 
   /**
@@ -54,12 +65,5 @@ export default class Formula extends MenuBase {
       return false;
     }
     return this.getAndCleanCacheOnce();
-  }
-
-  /**
-   * 声明绑定的快捷键，快捷键触发onClick
-   */
-  get shortcutKeys() {
-    return ['Ctrl-m'];
   }
 }

--- a/src/toolbars/hooks/Header.js
+++ b/src/toolbars/hooks/Header.js
@@ -15,10 +15,14 @@
  */
 import MenuBase from '@/toolbars/MenuBase';
 import { getSelection } from '@/utils/selection';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
 /**
  * 插入1级~5级标题
  */
 export default class Header extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('header', 'header');
@@ -29,6 +33,28 @@ export default class Header extends MenuBase {
       { iconName: 'h4', name: 'h4', onclick: this.bindSubClick.bind(this, '4') },
       { iconName: 'h5', name: 'h5', onclick: this.bindSubClick.bind(this, '5') },
     ];
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode(1)}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale.h1,
+      },
+      [`${CONTROL_KEY}-${getKeyCode(2)}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale.h2,
+      },
+      [`${CONTROL_KEY}-${getKeyCode(3)}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale.h3,
+      },
+      [`${CONTROL_KEY}-${getKeyCode(4)}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale.h4,
+      },
+      [`${CONTROL_KEY}-${getKeyCode(5)}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale.h5,
+      },
+    };
   }
 
   getSubMenuConfig() {
@@ -88,13 +114,5 @@ export default class Header extends MenuBase {
       this.setLessSelection(`${header} `, '');
     });
     return $selection.replace(/(^)([\s]*)([^\n]+)($)/gm, `$1${header} $3$4`);
-  }
-
-  /**
-   * 获得监听的快捷键
-   * 在windows下是Ctrl+1，在mac下是cmd+1
-   */
-  get shortcutKeys() {
-    return ['Ctrl-1', 'Ctrl-2', 'Ctrl-3', 'Ctrl-4', 'Ctrl-5', 'Ctrl-6'];
   }
 }

--- a/src/toolbars/hooks/Image.js
+++ b/src/toolbars/hooks/Image.js
@@ -15,13 +15,23 @@
  */
 import MenuBase from '@/toolbars/MenuBase';
 import { handleUpload, handleParams } from '@/utils/file';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
 /**
  * 插入图片
  */
 export default class Image extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('image', 'image');
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode('g')}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale[this.name],
+      },
+    };
   }
 
   /**
@@ -49,12 +59,5 @@ export default class Image extends MenuBase {
     });
     this.updateMarkdown = false;
     return selection;
-  }
-
-  /**
-   * 声明绑定的快捷键，快捷键触发onClick
-   */
-  get shortcutKeys() {
-    return ['Ctrl-g'];
   }
 }

--- a/src/toolbars/hooks/Italic.js
+++ b/src/toolbars/hooks/Italic.js
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 import MenuBase from '@/toolbars/MenuBase';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
 /**
  * 插入斜体的按钮
  */
 export default class Italic extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('italic', 'italic');
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode('i')}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale[this.name],
+      },
+    };
   }
 
   /**
@@ -58,13 +68,5 @@ export default class Italic extends MenuBase {
       this.setLessSelection('*', '*');
     });
     return $selection.replace(/(^)([^\n]+)($)/gm, '$1*$2*$3');
-  }
-
-  /**
-   * 获得监听的快捷键
-   * 在windows下是Ctrl+i，在mac下是cmd+i
-   */
-  get shortcutKeys() {
-    return ['Ctrl-i'];
   }
 }

--- a/src/toolbars/hooks/Link.js
+++ b/src/toolbars/hooks/Link.js
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 import MenuBase from '@/toolbars/MenuBase';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
 /**
  * 插入超链接
  */
 export default class Link extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('link', 'link');
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode('l')}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale[this.name],
+      },
+    };
   }
 
   /**
@@ -35,12 +45,5 @@ export default class Link extends MenuBase {
     }
     const title = selection ? selection : this.locale.link;
     return `[${title}](http://url.com) `;
-  }
-
-  /**
-   * 声明绑定的快捷键，快捷键触发onClick
-   */
-  get shortcutKeys() {
-    return ['Ctrl-l'];
   }
 }

--- a/src/toolbars/hooks/Publish.js
+++ b/src/toolbars/hooks/Publish.js
@@ -24,7 +24,7 @@ const supportPlatforms = ['wechat'];
 
 export default class Publish extends MenuBase {
   /**
-   * @param {Partial<import('@/Cherry').default> & {$currentMenuOptions?:import('~types/menus').CustomMenuConfig}} $cherry
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
    */
   constructor($cherry) {
     super($cherry);

--- a/src/toolbars/hooks/Size.js
+++ b/src/toolbars/hooks/Size.js
@@ -15,8 +15,12 @@
  */
 import MenuBase from '@/toolbars/MenuBase';
 import { getSelection } from '@/utils/selection';
+import { ALT_KEY, getKeyCode } from '@/utils/shortcutKey';
 
 export default class Size extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('size', 'size');
@@ -31,6 +35,24 @@ export default class Size extends MenuBase {
       'Alt-2': '17',
       'Alt-3': '24',
       'Alt-4': '32',
+    };
+    this.shortcutKeyMap = {
+      [`${ALT_KEY}-${getKeyCode(1)}`]: {
+        hookName: this.name,
+        aliasName: `${this.$cherry.locale[this.name]}-${this.$cherry.locale.small}`,
+      },
+      [`${ALT_KEY}-${getKeyCode(2)}`]: {
+        hookName: this.name,
+        aliasName: `${this.$cherry.locale[this.name]}-${this.$cherry.locale.medium}`,
+      },
+      [`${ALT_KEY}-${getKeyCode(3)}`]: {
+        hookName: this.name,
+        aliasName: `${this.$cherry.locale[this.name]}-${this.$cherry.locale.large}`,
+      },
+      [`${ALT_KEY}-${getKeyCode(4)}`]: {
+        hookName: this.name,
+        aliasName: `${this.$cherry.locale[this.name]}-${this.$cherry.locale.superLarge}`,
+      },
     };
   }
 
@@ -92,9 +114,5 @@ export default class Size extends MenuBase {
       this.setLessSelection(`!${size} `, '!');
     });
     return $selection.replace(/(^)([^\n]+)($)/gm, `$1!${size} $2!$3`);
-  }
-
-  get shortcutKeys() {
-    return ['Alt-1', 'Alt-2', 'Alt-3', 'Alt-4'];
   }
 }

--- a/src/toolbars/hooks/Strikethrough.js
+++ b/src/toolbars/hooks/Strikethrough.js
@@ -15,13 +15,23 @@
  */
 import MenuBase from '@/toolbars/MenuBase';
 import { getSelection } from '@/utils/selection';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
 /**
  * 删除线的按钮
  */
 export default class Strikethrough extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('strikethrough', 'strike');
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode('d')}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale[this.name],
+      },
+    };
   }
 
   $testIsStrike(selection) {
@@ -57,9 +67,5 @@ export default class Strikethrough extends MenuBase {
       this.setLessSelection(`${space}~~`, `~~${space}`);
     });
     return $selection.replace(/(^)[\s]*([\s\S]+?)[\s]*($)/g, `$1${space}~~$2~~${space}$3`);
-  }
-
-  get shortcutKeys() {
-    return ['Ctrl-d'];
   }
 }

--- a/src/toolbars/hooks/Underline.js
+++ b/src/toolbars/hooks/Underline.js
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 import MenuBase from '@/toolbars/MenuBase';
+import { CONTROL_KEY, getKeyCode } from '@/utils/shortcutKey';
 /**
  * 下划线按钮
  **/
 export default class Underline extends MenuBase {
+  /**
+   * @param {import('@/toolbars/MenuBase').MenuBaseConstructorParams} $cherry
+   */
   constructor($cherry) {
     super($cherry);
     this.setName('underline', 'underline');
+    this.shortcutKeyMap = {
+      [`${CONTROL_KEY}-${getKeyCode('u')}`]: {
+        hookName: this.name,
+        aliasName: this.$cherry.locale[this.name],
+      },
+    };
   }
 
   $testIsUnderline(selection) {
@@ -54,12 +64,5 @@ export default class Underline extends MenuBase {
     });
     // 如果选中的内容里没有下划线语法，则加上下划线
     return $selection.replace(/(^)([^\n]+)($)/gm, '$1 /$2/ $3');
-  }
-
-  /**
-   * 声明绑定的快捷键，快捷键触发onClick
-   */
-  get shortcutKeys() {
-    return ['Ctrl-u'];
   }
 }

--- a/src/utils/shortcutKey.js
+++ b/src/utils/shortcutKey.js
@@ -1,0 +1,308 @@
+import { mac } from 'codemirror/src/util/browser';
+
+export const SHIFT_KEY = 'Shift';
+export const ALT_KEY = 'Alt';
+// mac的command(meta)键，windows的ctrl键
+export const CONTROL_KEY = mac ? 'Meta' : 'Control';
+export const META_KEY = 'Meta';
+export const ENTER_KEY = 'Enter';
+export const ESCAPE_KEY = 'Escape';
+export const BACKSPACE_KEY = 'Backspace';
+
+export const shortKey2UnPlatformKey = {
+  [SHIFT_KEY]: (/** @type {boolean} */ isMac) => {
+    if (isMac) {
+      return {
+        text: '⇧',
+        tip: 'Shift',
+      };
+    }
+    return {
+      text: '⇧',
+      tip: 'Shift',
+    };
+  },
+  [CONTROL_KEY]: (/** @type {boolean} */ isMac) => {
+    if (isMac) {
+      return {
+        text: '⌃',
+        tip: 'Control',
+      };
+    }
+    return {
+      text: 'Ctrl',
+      tip: 'Control',
+    };
+  },
+  [ALT_KEY]: (/** @type {boolean} */ isMac) => {
+    if (isMac) {
+      return {
+        text: '⌥',
+        tip: 'Option',
+      };
+    }
+    return {
+      text: 'Alt',
+      tip: 'Alt',
+    };
+  },
+  [META_KEY]: (/** @type {boolean} */ isMac) => {
+    if (isMac) {
+      return {
+        text: '⌘',
+        tip: 'Command',
+      };
+    }
+    return {
+      text: '⊞',
+      tip: 'Windows',
+    };
+  },
+};
+
+/**
+ * 编辑属性的快捷键
+ * @type {string[]}
+ * @see https://developer.mozilla.org/zh-CN/docs/Web/API/UI_Events/Keyboard_event_key_values#editing_keys
+ */
+const editingKeys = [
+  'Backspace',
+  'Clear',
+  'Copy',
+  'CrSel',
+  'Cut',
+  'Delete',
+  'EraseEof',
+  'ExSel',
+  'Insert',
+  'Paste',
+  'Redo',
+  'Undo',
+];
+
+/**
+ * 导航快捷键
+ * @type {string[]}
+ * @see https://developer.mozilla.org/zh-CN/docs/Web/API/UI_Events/Keyboard_event_key_values#navigation_keys
+ */
+const navigationKeys = ['ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp'];
+
+/**
+ * whitespace_keys
+ * @type {string[]}
+ * @see https://developer.mozilla.org/zh-CN/docs/Web/API/UI_Events/Keyboard_event_key_values#whitespace_keys
+ */
+const whiteSpaceKeys = [' ', 'Tab', 'Enter'];
+
+/**
+ * 默认禁止的快捷键，主要是一些会对编辑器造成影响的快捷键
+ * @type {string[]}
+ */
+const defaultForbiddenKeys = [...editingKeys, ...navigationKeys, ...whiteSpaceKeys];
+
+/**
+ * 获取合法的快捷键
+ * @param {KeyboardEvent} event 键盘事件
+ * @param {string[]} customForbiddenKeys 自定义的禁止的快捷键
+ */
+export const getAllowedShortcutKey = (event, customForbiddenKeys = []) => {
+  const finalForbiddenKeys = [...defaultForbiddenKeys, ...customForbiddenKeys];
+  /** @type {string[]} */
+  const keyStack = [];
+  const isSpecialKey = event.metaKey || event.ctrlKey || event.altKey || event.shiftKey;
+  /**
+   * 这里用 key 是因为 code 带有布局特征
+   */
+  if (finalForbiddenKeys.includes(event.key)) {
+    return keyStack;
+  }
+  /**
+   * 这个逻辑体内就规定了特殊按键的顺序：Meta > Control > Alt > Shift，从而保证了快捷键的顺序而不会重复
+   * 也就是说这四个特殊键无论怎么按下，都会按照这个顺序排列
+   */
+  if (isSpecialKey) {
+    if (event.metaKey) {
+      keyStack.push(META_KEY);
+    }
+    if (event.ctrlKey) {
+      keyStack.push(CONTROL_KEY);
+    }
+    if (event.altKey) {
+      keyStack.push(ALT_KEY);
+    }
+    if (event.shiftKey) {
+      keyStack.push(SHIFT_KEY);
+    }
+  }
+  // 这里排除掉上面 isSpecialKey 的键，追加其他键
+  if (!keyStack.includes(event.key)) {
+    /**
+     * 这里用 code 的原因在于要抹平不同浏览器对键值的不同处理，以及按下Shift键时key的表示不同
+     * shfit、alt 等调节性键，在按下时，key的值会不同，但code的值是相同的
+     * @see https://developer.mozilla.org/zh-CN/docs/Web/API/KeyboardEvent/code
+     */
+    // 当前键是否是重复按下的
+    if (event.repeat) {
+      keyStack.push(event.code);
+      return keyStack;
+    }
+    keyStack.push(event.code);
+  }
+  return keyStack;
+};
+
+/**
+ * 判断一个快捷键栈是否只包含了修饰键+输入键
+ * @param {string[]} keyStack 快捷键栈
+ */
+export const keyStackIsModifierkeys = (keyStack) => {
+  // 不是数组或长度不为2的肯定不是，(shift/alt)+input
+  if (!Array.isArray(keyStack) || keyStack.length !== 2) {
+    return false;
+  }
+  const includeShiftKey = keyStack.includes(SHIFT_KEY);
+  const includeAltKey = keyStack.includes(ALT_KEY);
+  // 只包含 Shift 和 Alt 的肯定不是
+  if (includeShiftKey && includeAltKey && keyStack.length === 2) {
+    return false;
+  }
+  return (includeShiftKey || includeAltKey) && !keyStack.includes(META_KEY) && !keyStack.includes(CONTROL_KEY);
+};
+
+/**
+ * 缓存快捷键映射
+ * @param {string} cherryInstanceId cherry 实例id
+ * @param {import('@/toolbars/MenuBase').HookShortcutKeyMap} keyMap 快捷键映射
+ * @returns
+ */
+export const storageKeyMap = (cherryInstanceId, keyMap) => {
+  if (!keyMap || typeof keyMap !== 'object') {
+    throw new Error('keyMap must be a object');
+  }
+  return window.localStorage.setItem(`cherry-shortcut-keymap-${cherryInstanceId}`, JSON.stringify(keyMap));
+};
+
+/**
+ * 获取缓存快捷键映射
+ * @param {string} cherryInstanceId cherry 实例id
+ * @returns
+ */
+export const getStorageKeyMap = (cherryInstanceId) => {
+  const shortcutKeyMapStorage = window.localStorage.getItem(`cherry-shortcut-keymap-${cherryInstanceId}`);
+  if (shortcutKeyMapStorage) {
+    try {
+      /** @type {import('@/toolbars/MenuBase').HookShortcutKeyMap} */
+      const res = JSON.parse(shortcutKeyMapStorage);
+      return res;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+  return null;
+};
+
+/**
+ * 将快捷键栈转换为唯一字符串
+ * @param {string[]} keyStack 快捷键栈
+ * @returns
+ */
+export const keyStack2UniqueString = (keyStack) => {
+  if (!Array.isArray(keyStack)) {
+    throw new Error('keyStack must be a array');
+  }
+  return keyStack.join('-');
+};
+
+/**
+ * 清除cherry 实例的快捷键映射
+ */
+export const clearAllStorageKeyMap = () => {
+  // 清除所有 cherry 实例的快捷键映射，即删除以`cherry-shortcut-keymap-` 开头的所有 localStorage
+  Object.keys(window.localStorage).forEach((key) => {
+    if (key.startsWith('cherry-shortcut-keymap-')) {
+      window.localStorage.removeItem(key);
+    }
+  });
+};
+
+/**
+ * 更新缓存中的快捷键映射
+ * @param {string} cherryInstanceId cherry 实例id
+ * @param {string} oldShortcutKey 旧的快捷键
+ * @param {import('@/toolbars/MenuBase').HookShortcutKeyMap} keyMap 快捷键映射
+ */
+export const updateStorageKeyMap = (cherryInstanceId, oldShortcutKey, keyMap) => {
+  const originStorageKeyMap = getStorageKeyMap(cherryInstanceId);
+  if (originStorageKeyMap) {
+    // 先删除旧值
+    delete originStorageKeyMap[oldShortcutKey];
+    // 再添加新值
+    Object.assign(originStorageKeyMap, keyMap);
+    storageKeyMap(cherryInstanceId, originStorageKeyMap);
+  }
+};
+
+/**
+ * 将快捷键代码转换为平台对应的快捷键
+ * @param {string} code 源code
+ * @param {boolean} isMac 是否是mac平台
+ */
+export const shortcutCode2Key = (code, isMac) => {
+  if (code in shortKey2UnPlatformKey) {
+    /** @type {keyof shortKey2UnPlatformKey} */
+    // @ts-ignore
+    const origin = code;
+    const func = shortKey2UnPlatformKey[origin];
+    if (typeof func === 'function') {
+      return func(isMac);
+    }
+  }
+  // 由于code包含了Key、Digit等，所以需要替换掉
+  const text = code.replace(/Key|Digit/g, '');
+  return {
+    text,
+    tip: text,
+  };
+};
+
+/**
+ * 将快捷键栈转换为平台无关的唯一字符串
+ * @param {string[]} keyStack 快捷键栈
+ * @param {boolean} isMac 是否是mac平台
+ * @returns
+ */
+export const keyStack2UnPlatformUniqueString = (keyStack, isMac) => {
+  if (!Array.isArray(keyStack)) {
+    throw new Error('keyStack must be a array');
+  }
+  return keyStack2UniqueString(keyStack.map((code) => shortcutCode2Key(code, isMac).text));
+};
+
+/**
+ * 获取快捷键
+ * @param {string|number} key 易读的键
+ * @example [0-9, a-z]
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
+ */
+export const getKeyCode = (key) => {
+  if (typeof key === 'number') {
+    return `Digit${key}`;
+  }
+  if (typeof key !== 'string') {
+    throw new Error('key must be a string or number');
+  }
+  // 一次只能输入一个字符
+  if (key.length > 1) {
+    throw new Error(`key length must be 1, but get ${key.length}`);
+  }
+  const upperCaseKey = key.toUpperCase();
+  // 字符串数字
+  if (/\d/.test(upperCaseKey)) {
+    return `Digit${upperCaseKey}`;
+  }
+  // 字符串字母
+  if (/[A-Z]/.test(upperCaseKey)) {
+    return `Key${upperCaseKey}`;
+  }
+};

--- a/types/cherry.d.ts
+++ b/types/cherry.d.ts
@@ -340,3 +340,21 @@ export interface CherryFileUploadHandler {
     callback: (url: string, params?: {name?: string, poster?: string, isBorder?: boolean, isShadow?: boolean, isRadius?: boolean; width?: string, height?: string}
   ) => void): void;
 }
+
+
+type ShortcutKeyMapStruct = {
+  /**
+   * 原始hook
+   */
+  hookName: string;
+  /**
+   * 展示名称
+   */
+  aliasName: string;
+  /**
+   * 其他扩展字段
+   * 如果存在则会赋值给 data-[fieldName]=value 存储记录
+   * @summary 切记不要使用驼峰，因为dataset 会全部转成全小写，除非你在取值的时候能记住，否则永远不要这么做
+   */
+  [x: string]: string | number;
+}

--- a/types/editor.d.ts
+++ b/types/editor.d.ts
@@ -15,6 +15,7 @@
  */
 import CodeMirror from 'codemirror';
 import Cherry from '../src/Cherry.js';
+import { EditorMode } from './cherry.js';
 
 interface EditorEventMap {
   onBlur: FocusEvent;
@@ -66,4 +67,6 @@ export type EditorConfiguration = {
   $cherry?: Cherry;
   /** 书写风格，normal 普通 | typewriter 打字机 | focus 专注，默认normal */
   writingStyle?: string;
+  /** 编辑器初始化后的模式 */
+  defaultModel?: EditorMode;
 };


### PR DESCRIPTION
# 现在你可以自定义hook的快捷键啦！

## For User
 点击设置按钮->点击快捷键配置即可，跟`vscode`一样，双击快捷键即可编辑

## For Dev
先查看对应hook的快捷键，API为：`cherry.toolbar.menus.hooks['header'].shortcutKeyMap` 把 `header` 换成你的即可

API更新快捷键：`cherry.toolbar.menus.hooks['header'].updateShortcutKeyMap(旧的快捷键, 新的快捷键)`

注：旧的快捷键可以通过上面的API来获取，但新的API一定要按照旧的快捷键来，如果你不知道规则，请先查看 [https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values](Mdn官方说明)，或者参考上面的编辑方法，观察 `localStorage` 的变化来实现

对了，如果你在一个页面需要打开多个 `cherry`，他们的快捷键配置互不影响