### PR TITLE
fix(type): type error in config

### DIFF
--- a/types/cherry.d.ts
+++ b/types/cherry.d.ts
@@ -178,7 +178,7 @@ export interface CherryEditorOptions {
   showSuggestList?: boolean;
 }
 
-export type CherryLifecycle = (text: String, html: String) => void;
+export type CherryLifecycle = (text: string, html: string) => void;
 
 export interface CherryPreviewerOptions {
   dom: HTMLDivElement | false;
@@ -237,7 +237,7 @@ export type CherryDefaultToolbar =
   | 'settings';
 
 export type CherryInsertToolbar = {
-  insert: string[];
+  string: string[];
 };
 
 export type CherryDefaultBubbleToolbar =


### PR DESCRIPTION
在`toolbar`中 设置包含二级菜单栏的时候，遇到一级菜单栏错误。
这里设置成了`string`类型进行通配，但是感觉这种失去了约束力。

![a9b29c57fd2a1770c6b697bbffc81e5](https://github.com/Tencent/cherry-markdown/assets/81673017/bb14616c-3166-45ef-9d4d-335499489b0e)
![cab7e2e1efa2605d2c97d1e3916f4ea](https://github.com/Tencent/cherry-markdown/assets/81673017/522e71d2-8f7d-4b9b-b110-a3de3c108070)
