### PR TITLE
style: 默认主题样式精调

### DIFF
--- a/src/sass/cherry.scss
+++ b/src/sass/cherry.scss
@@ -392,7 +392,7 @@
     }
 
     &:hover {
-      background: rgba(0, 0, 0, 0.05);
+      background: #ced4da;
 
       .ch-icon {
         color: $toolbarBtnColorLight;

--- a/src/sass/markdown.scss
+++ b/src/sass/markdown.scss
@@ -283,7 +283,7 @@
     white-space: normal;
     color: #495057;
     background-color: #e9ecef;
-    border: 0.1em solid #ced4da;
+    border: 1px solid #ced4da;
 
     [data-inline-code-theme='black'] & {
       color: #3f4a56;

--- a/src/sass/markdown.scss
+++ b/src/sass/markdown.scss
@@ -281,8 +281,9 @@
     padding: 0.1em;
     border-radius: 0.3em;
     white-space: normal;
-    color: #f85353;
-    background-color: #e5e5e5;
+    color: #495057;
+    background-color: #e9ecef;
+    border: 0.1em solid #ced4da;
 
     [data-inline-code-theme='black'] & {
       color: #3f4a56;

--- a/src/sass/themes/default.scss
+++ b/src/sass/themes/default.scss
@@ -48,7 +48,7 @@
 
   /** 光标focus到空行时联想出的按钮 */
   .cherry-floatmenu {
-
+    background-color: #e9ecef;
   }
 
   .cherry-editor {

--- a/src/sass/themes/default.scss
+++ b/src/sass/themes/default.scss
@@ -141,7 +141,9 @@
   }
   
   a {
-    
+    &:hover {
+      text-decoration: underline;
+    }
   }
   
   strong {
@@ -239,6 +241,9 @@
 
     /** 目录 */
   .toc {
+    a:hover {
+      text-decoration: none;
+    }
     .toc-title {
 
     }

--- a/src/sass/themes/default.scss
+++ b/src/sass/themes/default.scss
@@ -39,6 +39,12 @@
     }
   }
 
+  // 更改编辑区域选中文字区域的背景色
+  // 覆盖了 codemirror.css 中的默认样式
+  .CodeMirror-focused .CodeMirror-selected { background: #bac8ff; }
+  .CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background: #bac8ff; }
+  .CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection { background: #bac8ff; }
+
 
   /** 光标focus到空行时联想出的按钮 */
   .cherry-floatmenu {

--- a/src/sass/variable.scss
+++ b/src/sass/variable.scss
@@ -15,7 +15,7 @@ $editorBg: #f8fafb;
 $previewBg: #f8fafb;
 $fontColor: #3f4a56;
 $linkColor: #3582fb;
-$linkHoverColor: #056bad;
+$linkHoverColor: #364fc7;
 $borderColor: #dfe6ee;
 $toolbarSplitColor: #dfe6ee;
 $fullWidthColor: #d71616;
@@ -66,7 +66,7 @@ $editorKeywordColor: $fontColor;
 
 // 工具栏
 // 暗色
-$toolbarBgDark: #364fc7;
+$toolbarBgDark: $linkHoverColor;
 $toolbarShadowDark: $shadow;
 $toolbarBtnBgDark: transparent;
 $toolbarBtnColorDark: #d7e6fe;

--- a/src/sass/variable.scss
+++ b/src/sass/variable.scss
@@ -66,7 +66,7 @@ $editorKeywordColor: $fontColor;
 
 // 工具栏
 // 暗色
-$toolbarBgDark: #20304b;
+$toolbarBgDark: #364fc7;
 $toolbarShadowDark: $shadow;
 $toolbarBtnBgDark: transparent;
 $toolbarBtnColorDark: #d7e6fe;


### PR DESCRIPTION
该 pr 调整默认主题的样式

对应 issue: [https://github.com/Tencent/cherry-markdown/issues/800](https://github.com/Tencent/cherry-markdown/issues/800)

具体修改内容都已在 commit 中说明。

调整之前预览：
![image](https://github.com/user-attachments/assets/342b4a6b-26dd-4299-ba8e-63bedff0a07d)


调整之后预览：
![image](https://github.com/user-attachments/assets/ccef1cc2-615f-4954-b8c4-4690b30d97d9)

调整参考：
- 网站设计最重要的11个设计原则：https://www.da-vinci.com.tw/cn/blog/design-improve-list
- 主要的网页设计原则：https://appmaster.io/zh/blog/zhu-yao-de-wang-ye-she-ji-yuan-ze
- 8个web设计原则，看看大厂是如何做设计的：https://pixso.cn/designskills/wangyejiemiansjyz/
- 每位设计师都应该知道的20条网站设计原则：https://www.sumaarts.com/share/1514.html
- 设计一个完美的超链接——没那么简单：https://www.woshipm.com/pd/82538.html
- 设计超链接:提示和最佳实践：https://www.psicolabor.com/blog/web-design/designing-hyperlinks-tips-and-best-practices/
- 设计完美的超链接 - 它并不像你想象的那么简单：https://www.iran-store.com/blog/web-design/hyperlink-design/

现阶段发现的问题：
1. 网页全屏按钮失效
2. 建议增加回到顶部按钮
3. 悬浮菜单（cherry-floatmenu）的位置应该放在当前编辑行的上方，而不是右方，容易误点击
4. 跳转新窗口超链接的`a::after`元素图标不直观，会让人认为这只是一个普通链接，不是跳转新窗口的链接，同时不跳转新窗口的链接又没有`a::after`，就会造成超链接元素样式风格的割裂，普通超链接、蓝色文字以及跳转新窗口的超链接三者没有明显的区分，易造成混淆。应该更换一个更直观的图标。例如：
![新窗口](https://github.com/user-attachments/assets/442abc07-7b18-4fea-83a7-d2e65b44f022)

后续将继续调整暗黑主题的样式。