### PR TITLE
fix: rename npm-dev-test package

### DIFF
--- a/.github/workflows/pr-merge-dev-npm_preview.yml
+++ b/.github/workflows/pr-merge-dev-npm_preview.yml
@@ -52,7 +52,7 @@ jobs:
 
              # 设置环境变量
              echo "PACKAGE_VERSION=$VERSION" >> "$GITHUB_ENV"
-             package_name="@cherry-markdown/preview-dev"
+             package_name="@cherry-markdown-publisher/preview-dev"
              echo "PACKAGE_NAME=$package_name" >> "$GITHUB_ENV"
 
              # 打印当前版本号


### PR DESCRIPTION
因`@cherry-markdown`已经在npm被注册，所以修改替换为`cherry-markdown-publisher`
<img width="962" alt="17270669182976" src="https://github.com/user-attachments/assets/6bb71d2b-33f7-4210-a4c3-10399ffc95c6">
