### PR TITLE
feat(vscodePlugin): add right click menu shortcut key `F10`

### DIFF
--- a/vscodePlugin/package.json
+++ b/vscodePlugin/package.json
@@ -30,7 +30,7 @@
     "commands": [
       {
         "command": "cherrymarkdown.preview",
-        "title": "Open Cherry Markdown"
+        "title": "Preview In Cherry Markdown"
       }
     ],
     "menus": {
@@ -42,6 +42,13 @@
         }
       ]
     },
+    "keybindings": [
+      {
+        "command": "cherrymarkdown.preview",
+        "key": "F10",
+        "when": "editorTextFocus && editorLangId == markdown"
+      }
+    ],
     "icons": {
       "distro-ubuntu": {
         "description": "cherry-markdown icon",


### PR DESCRIPTION
* rename right-click menu name  "Preview In Cherry Markdown"

close #924

![image](https://github.com/user-attachments/assets/5de6940f-51b5-452e-8a67-abf414760ce6)
