### PR TITLE
fix(vscodePlugin): vscode dark mode and it's default theme，black scrollbar appears

### DIFF
--- a/vscodePlugin/web-resources/index.css
+++ b/vscodePlugin/web-resources/index.css
@@ -5,3 +5,9 @@ body {
     height: 100vh !important;
     overflow: hidden;
 }
+
+@supports selector(::-webkit-scrollbar) {
+    html {
+        scrollbar-color: unset;
+    }
+}


### PR DESCRIPTION
refer to: https://github.com/microsoft/vscode/issues/213045#issuecomment-2211442905

![image](https://github.com/user-attachments/assets/0dc6f3f2-63c3-44aa-aee6-66bc04b6d550)
![image](https://github.com/user-attachments/assets/9a844da3-e15f-4613-84d8-f6ffee12f221)
