### PR TITLE
chore(ci): remove the file path filtering rules in build ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,6 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
-    paths:   # 这里是用来指定哪个文件更改，才会触发的
-      - 'src/**'
-      - 'package.json'
-      - 'types/**'
-      - 'examples/**'
 
 jobs:
   build:


### PR DESCRIPTION
因当前repo内存在分支保护规则，在dev分支下必须每个pr都得经过`build.yml`ci 的成功运行之后才允许合并，当前的文件路径过滤，会导致不在匹配路径下的文件修改pr不能被允许合并。

![image](https://github.com/user-attachments/assets/6a71829c-d696-4606-bb24-0444c36d3d91)
