### PR TITLE
fix(vscodePlugin): relative path img

### DIFF
--- a/vscodePlugin/web-resources/scripts/index.js
+++ b/vscodePlugin/web-resources/scripts/index.js
@@ -245,15 +245,20 @@ const basicConfig = {
     // eslint-disable-next-line no-undef
     changeString2Pinyin: pinyin,
     beforeImageMounted(srcProp, srcValue) {
+      const { _activeTextEditorPath } = window;
+
+      //  http路径 或 data路径
       if (isHttpUrl(srcValue) || isDataUrl(srcValue)) {
         return {
           src: srcValue,
         };
       }
-      // eslint-disable-next-line no-underscore-dangle
-      const basePath = window._baseResourcePath || '';
+      // TODO: 绝对路径(如windows上D:\GithubDesktop\cherry-markdown\README.md)
+
+      // 相对路径
+      const absolutePath = new URL(srcValue, _activeTextEditorPath).href;
       return {
-        src: path.join(basePath, srcValue),
+        src: absolutePath,
       };
     },
     onClickPreview: (e) => {


### PR DESCRIPTION
在之前，会获取工作区路径+markdown中文本的相对路径进行拼接，当vscode的打开的工作区不同的时候就会导致图片加载失败。
![011748bb5dc7467f3ae5eaaec81ed42](https://github.com/user-attachments/assets/af469d79-e613-4e60-9744-0b53e20d5b61)

现在获取当前活动的markdown文件路径，通过计算相对于这个markdown文件的相对路径获取最终的图片绝对路径进行加载。
![5ef15115250a61095fa0aa90eba2ddcf](https://github.com/user-attachments/assets/83ac7c45-9633-4c3f-97e9-58bfba81a579)
