### PR TITLE
fix(vscodePlugin): prevent the default redirect of links in vscode webview

### DIFF
--- a/vscodePlugin/web-resources/scripts/index.js
+++ b/vscodePlugin/web-resources/scripts/index.js
@@ -58,18 +58,25 @@ const customMenuFont = Cherry.createMenuHook('字体样式', {
 
 
 /** 处理 a 链接跳转问题 */
-const onClickLink = (target) => {
+const onClickLink = (e, target) => {
+
+
   // 这里不能直接使用 target.href，因为本地相对文件地址会被vscode转成`webview://`协议
   const href = target.attributes?.href.value;
-  if (!href) {
+
+  const hrefValidation = href ? href : 'href-invalid';
+  if (isHttpUrl(hrefValidation) || hrefValidation) {
+    // 阻止a链接在webview的默认跳转行为
+    e.preventDefault();
     vscode.postMessage({
       type: 'open-url',
-      data: 'href-invalid',
+      data: href,
     });
-  };
+    return;
+  }
   vscode.postMessage({
     type: 'open-url',
-    data: href,
+    data: 'href-invalid',
   });
 };
 
@@ -266,11 +273,11 @@ const basicConfig = {
       switch (target?.nodeName) {
         case 'SPAN':
           if (target?.parentElement?.nodeName === 'A') {
-            onClickLink(target?.parentElement);
+            onClickLink(e, target?.parentElement);
           }
           break;
         case 'A':
-          onClickLink(target);
+          onClickLink(e, target);
           break;
       };
     },


### PR DESCRIPTION
当前如果在插件内打开一个 `https` / `http` 的链接，会自动使用默认的浏览器打开这个地址，但是 vscode plugin webview 也会发生跳转，从而产生黑屏。

https://github.com/user-attachments/assets/045e06eb-afe6-4888-aa05-8376e7605fc5

当前，在检测到为 `https` / `http` 的 `A` 链接时，依旧使用默认浏览器打开这个地址，但是阻止 `A` 链接的默认跳转行为。

https://github.com/user-attachments/assets/c980bb53-0e7c-4ac0-a742-2080984f1dfb

