### PR TITLE
fix(type): `insert` api's `normal-table-row*col` type constraints

### DIFF
--- a/src/toolbars/Toolbar.js
+++ b/src/toolbars/Toolbar.js
@@ -34,7 +34,9 @@ import {
  * - ol(1)有序
  * - ul(2)无序列表
  * - checklist(3)checklist
- * @typedef {(insert:'hr'|'br'|'code'|'formula'|'checklist'|'toc'|'link'|'image'|'video'|'audio'|'normal-table'|'normal-table-row*col')=>void} Insert 向cherry编辑器中插入特定语法
+ * @typedef {`normal-table-${number}*${number}`} normalTableRowCol 插入表格语法约束
+ * 
+ * @typedef {(insert:'hr'|'br'|'code'|'formula'|'checklist'|'toc'|'link'|'image'|'video'|'audio'|'normal-table'|normalTableRowCol)=>void} Insert 向cherry编辑器中插入特定语法(需要在`toolbar`中预先配置功能)
  * - hr 水平分割线
  * - br 换行
  * - code 代码块

--- a/src/toolbars/Toolbar.js
+++ b/src/toolbars/Toolbar.js
@@ -35,7 +35,6 @@ import {
  * - ul(2)无序列表
  * - checklist(3)checklist
  * @typedef {`normal-table-${number}*${number}`} normalTableRowCol 插入表格语法约束
- * 
  * @typedef {(insert:'hr'|'br'|'code'|'formula'|'checklist'|'toc'|'link'|'image'|'video'|'audio'|'normal-table'|normalTableRowCol)=>void} Insert 向cherry编辑器中插入特定语法(需要在`toolbar`中预先配置功能)
  * - hr 水平分割线
  * - br 换行


### PR DESCRIPTION
close #827
将其约束为 `normal-table-${number}*${number}`
约束示范:
<img width="566" alt="b5e45e42603512fbb893ea3fe1b4438" src="https://github.com/user-attachments/assets/dbfcef8e-9a24-4417-9ddc-d84ca80ca6b2" />
<img width="421" alt="6d7aceed8ad24bc9fdaa6dead6c201c" src="https://github.com/user-attachments/assets/04ce26cf-1428-417d-b11a-2cfdf2f2c8af" />
<img width="407" alt="33f78c8aba34f788d75f88a4157c287" src="https://github.com/user-attachments/assets/0ee9cda8-d0d9-45d4-bce6-1dc2c08ab7d4" />
