### PR TITLE
fix: monorepo `cherry-markdown` local link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,16 +25,7 @@ yarn-error.log*
 package-lock.json
 pnpm-lock.yaml
 
-#client
-/client/yarn.lock
-
-# docs
-/docs/.vitepress/cache/
-/docs/.vitepress/dist/
-
-
-#vscodePlugin
-/vscodePlugin/yarn.lock
+packages/**/yarn.lock
 
 # config
 examples/cherry-markdown-publish/src/common/config/*.yaml

--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
     "packages/*",
     "examples/*"
   ],
-  "scripts": {},
+  "scripts": {
+    "dev": "yarn workspace cherry-markdown dev",
+    "build": "yarn workspace cherry-markdown build",
+    "dev:client": "yarn workspace @cherry-markdown/client dev",
+    "build:client": "yarn workspace @cherry-markdown/client build",
+    "preview:client": "yarn workspace @cherry-markdown/client preview",
+    "tauri:client": "yarn workspace @cherry-markdown/client tauri"
+  },
   "devDependencies": {
     "@babel/eslint-parser": "^7.12.1",
     "@typescript-eslint/eslint-plugin": "^4.27.0",
@@ -43,5 +50,6 @@
   "engines": {
     "node": ">=18",
     "yarn": "^1.22.22"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/cherry-markdown/package.json
+++ b/packages/cherry-markdown/package.json
@@ -12,7 +12,6 @@
   "style": "./dist/cherry-markdown.min.css",
   "types": "./dist/types/index.d.ts",
   "directories": {
-    "doc": "docs",
     "example": "examples"
   },
   "files": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "@tauri-apps/plugin-fs": "2.2.0",
     "pinia": "^2.2.4",
-    "cherry-markdown": "workspace:*"
+    "cherry-markdown": "*"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5699,18 +5699,6 @@ cheerio@1.0.0-rc.12:
     parse5 "^7.0.0"
     parse5-htmlparser2-tree-adapter "^7.0.0"
 
-"cherry-markdown@workspace:*":
-  version "0.8.58"
-  resolved "https://registry.npmjs.org/cherry-markdown/-/cherry-markdown-0.8.58.tgz#b323afc989da7e3a1b24b5515975c9eecf4d7907"
-  integrity sha512-/UV1+qyv7X+TVKQMimuh0oiDf/Ysdp3KfJZtGfVLYSYjlrTnTkmbZ2bTQO/NUgTlNaQbyOsanBkw9U2VwHUzMA==
-  dependencies:
-    "@types/codemirror" "^0.0.108"
-    "@types/dompurify" "^2.2.3"
-    crypto-js "^4.2.0"
-    jsdom "~19.0.0"
-  optionalDependencies:
-    mermaid "9.4.3"
-
 chokidar@3.5.1:
   version "3.5.1"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"


### PR DESCRIPTION
可以正常引用本地的 cherry-markdown 代码(本地构建后的产物)

refer: https://stackoverflow.com/questions/73057794/yarn-not-installing-packages-from-workspace-but-instead-tries-pulling-down-from