### PR TITLE
ci(global): 使用 ci 来操作将 vscodePlugin 移除 workspace 外构建

### DIFF
--- a/.github/workflows/build-client-release.yaml
+++ b/.github/workflows/build-client-release.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: Build Tauri
         run: |
           yarn --network-timeout 100000
+          yarn build
           yarn build:client ${{ matrix.args }}
 
       - name: Upload macOS Release Asset (aarch64-apple-darwin)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Publish VSCode Extension
         if: ${{ contains(steps.changesets.outputs.publishedPackages, '"name":"@cherry-markdown/vscode-plugin"') }}
         run: |
-          jq ".workspaces = [\"examples/cherry-markdown\", \"examples/client\"]" package.json > workspaces.json && mv workspaces.json package.json
+          jq ".workspaces = [\"packages/cherry-markdown\", \"packages/client\", \"examples/*\"]" package.json > workspaces.json && mv workspaces.json package.json
           npm install -g vsce
           cd packages/vscodePlugin
           yarn

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,8 +49,10 @@ jobs:
       - name: Publish VSCode Extension
         if: ${{ contains(steps.changesets.outputs.publishedPackages, '"name":"@cherry-markdown/vscode-plugin"') }}
         run: |
+          jq ".workspaces = [\"examples/cherry-markdown\", \"examples/client\"]" package.json > workspaces.json && mv workspaces.json package.json
           npm install -g vsce
           cd packages/vscodePlugin
+          yarn
           jq '.name="cherry-markdown"' package.json > temp.json && mv temp.json package.json
           vsce package
           vsce publish

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "license": "Apache-2.0",
   "private": true,
   "workspaces": [
-    "packages/cherry-markdown",
-    "packages/@cherry-markdown/client",
+    "packages/*",
     "examples/*"
   ],
   "scripts": {

--- a/packages/vscodePlugin/package.json
+++ b/packages/vscodePlugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cherry-markdown",
+  "name": "@cherry-markdown/vscode-plugin",
   "displayName": "Cherry Markdown",
   "description": "A markdown previewer powered by [cherry-markdown](https://github.com/Tencent/cherry-markdown)",
   "version": "0.0.18",


### PR DESCRIPTION
https://github.com/Tencent/cherry-markdown/pull/1040 这样设置会导致 changeset 不能正确运行，则将 vscodeplugin 移除 workspace 外构建的行为都使用 ci 来完成