### PR TITLE
ci: beautify release message

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.5/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@cherry-markdown/changesets-changelog-github", {"repo": "Tencent/cherry-markdown"}],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/silly-dingos-fix.md
+++ b/.changeset/silly-dingos-fix.md
@@ -1,0 +1,7 @@
+---
+'cherry-markdown': patch
+'@cherry-markdown/vscode-plugin': patch
+'@cherry-markdown/client': patch
+---
+
+ci: beautify release message


### PR DESCRIPTION
使用 `@cherry-markdown/changesets-changelog-github` 依赖，二次处理每一条 release 信息进行格式化。
效果如

https://github.com/cherry-markdown/changesets-changelog-github/releases/tag/%40cherry-markdown%2Fchangesets-changelog-github%400.0.1

![image](https://github.com/user-attachments/assets/362527d0-8869-4cda-bc09-0c7364c019b3)
