### PR TITLE
ci: copy README.md file in the root dir to the core release dir

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,10 @@ jobs:
       - name: Publish cherry-markdown
         if: ${{ contains(steps.changesets.outputs.publishedPackages, '"name":"cherry-markdown"') }}
         run: |
+          cp README.CN.md packages/cherry-markdown/
+          cp README..md packages/cherry-markdown/
+          cp README.JP.md packages/cherry-markdown/
+           
           cd packages/cherry-markdown
           npm publish --access public
         env:


### PR DESCRIPTION
目前 `./packages/cherry-markdown` 目录是没有 README 说明文件的，而如果根目录和 `./packages/cherry-markdown` 目前都创建一份文件很容易导致文件内容不一样，所以当前在每次发布 npm 包时使用 ci 在发布之前将文件移动到 core 目录内随着 core 一起打包