### PR TITLE
添加GitHub Pages部署工作流

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,45 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: "yarn"
+
+      - name: Install dependencies
+        uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: install
+
+      - name: Run Build
+        uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: build
+
+      - name: Prepare deployment assets
+        run: |
+          mkdir -p public
+          cp -r dist public/
+          cp -r examples public/
+          cp -r logo public/
+          cp index.html public/
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: public
+          destination_branch: gh-pages


### PR DESCRIPTION
1、添加gh-pages分支用于demo预览（已完成）
2、增加脚本，部署到gh-pages（当前pr）
3、github pages预览配置由当前的main分支调整为gh-pages（后续工作）
4、删除main分支的dist文件夹（后续工作）