### PR TITLE
fix(vscode): add build script

### DIFF
--- a/packages/vscodePlugin/package.json
+++ b/packages/vscodePlugin/package.json
@@ -166,6 +166,7 @@
     }
   },
   "scripts": {
+    "build": "vsce package",
     "vscode:prepublish": "npm run package",
     "compile": "webpack",
     "watch": "webpack --watch",


### PR DESCRIPTION
此 pr https://github.com/Tencent/cherry-markdown/pull/1112 的 vscodePlugin ci 中调用了 vscodePlugin 的 script build ，但是实际并没有声明，此处进行补充。