### PR TITLE
fix: release ci some code format errors

### DIFF
--- a/.changeset/dirty-geese-turn.md
+++ b/.changeset/dirty-geese-turn.md
@@ -1,5 +1,5 @@
 ---
-'cherry-markdown': major
+'cherry-markdown': minor
 ---
 
 fix: #1093 修复开启流式虚拟光标时，代码块被破坏的问题

--- a/.changeset/good-lemons-yawn.md
+++ b/.changeset/good-lemons-yawn.md
@@ -1,5 +1,5 @@
 ---
-'cherry-markdown': major
+'cherry-markdown': minor
 ---
 
 fix: 1109 增加禁用 html 的配置能力

--- a/.changeset/rich-papayas-melt.md
+++ b/.changeset/rich-papayas-melt.md
@@ -1,5 +1,5 @@
 ---
-'cherry-markdown': major
+'cherry-markdown': minor
 ---
 
 fix: #1095 去掉告警信息

--- a/.changeset/rotten-chefs-relate.md
+++ b/.changeset/rotten-chefs-relate.md
@@ -1,5 +1,5 @@
 ---
-'cherry-markdown': 'minor'
+'cherry-markdown': minor
 ---
 
 feat: 支持有序列表英文字母

--- a/.changeset/sweet-carrots-study.md
+++ b/.changeset/sweet-carrots-study.md
@@ -1,5 +1,5 @@
 ---
-'cherry-markdown': major
+'cherry-markdown': minor
 ---
 
 fix: #1099 and fix: #1098 修复自动补全加粗功能和无序列表的冲突， 并且增加对\<和\>转义的支持

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "example:react": "yarn workspace @cherry-markdown/react_demo dev"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.27.12",
     "@babel/eslint-parser": "^7.12.1",
+    "@cherry-markdown/changesets-changelog-github": "^0.0.1",
     "@commitlint/config-conventional": "^19.6.0",
     "@typescript-eslint/eslint-plugin": "^4.27.0",
     "@typescript-eslint/parser": "^4.27.0",
@@ -47,9 +49,6 @@
   },
   "lint-staged": {
     "*.js": "eslint --fix"
-  },
-  "dependencies": {
-    "@changesets/cli": "^2.27.12"
   },
   "engines": {
     "node": ">=18",

--- a/packages/cherry-markdown/CHANGELOG.md
+++ b/packages/cherry-markdown/CHANGELOG.md
@@ -1,8 +1,8 @@
-# Changelog
+# Change Log
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+## 0.8.58
 
-### [0.8.58](https://github.com/Tencent/cherry-markdown/compare/v0.8.57...v0.8.58) (2025-01-13)
+### Patch Changes
 
 
 ### Features

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@cherry-markdown/client",
-  "private": true,
   "version": "0.1.0",
   "type": "module",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,6 +1991,14 @@
     picocolors "^1.1.0"
     semver "^7.5.3"
 
+"@changesets/get-github-info@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz#faba66a20a3a5a0cbabea28efd43c9ede7429f11"
+  integrity sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==
+  dependencies:
+    dataloader "^1.4.0"
+    node-fetch "^2.5.0"
+
 "@changesets/get-release-plan@^4.0.8":
   version "4.0.8"
   resolved "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.8.tgz#528ef38720e3c09aec5a3ff49c8aea8e318347ef"
@@ -2084,6 +2092,14 @@
     fs-extra "^7.0.1"
     human-id "^4.1.1"
     prettier "^2.7.1"
+
+"@cherry-markdown/changesets-changelog-github@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/@cherry-markdown/changesets-changelog-github/-/changesets-changelog-github-0.0.1.tgz#776659a7a6b68a8b95b8932562b56042b4c4084c"
+  integrity sha512-OnSb5HzA63LMcnrNVWWhQmfH+OSnu+UsuEzk4nJoTfe/aa9QWLRxtbJJw7sPJNpUtdOHHWRhuMGq0J1gZHNHHQ==
+  dependencies:
+    "@changesets/get-github-info" "^0.6.0"
+    dotenv "^16.0.3"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -7746,6 +7762,11 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+dataloader@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+  integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
+
 dateformat@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz"
@@ -8144,6 +8165,11 @@ dotenv@16.4.5:
   version "16.4.5"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
+dotenv@^16.0.3:
+  version "16.4.7"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
+  integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
 
 dotgitignore@^2.1.0:
   version "2.1.0"
@@ -14041,9 +14067,9 @@ node-environment-flags@^1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.7.0"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"


### PR DESCRIPTION
在 changeset 发布 ci 工作流里有以下问题导致发布不正确。

1. devDependencies 添加 `@cherry-markdown/changesets-changelog-github`
2.  `.changeset` 记录版本错误，将 `major`(主版本) 修改为 `minor`(次版本)
3. packages/client/package.json 将 `"private": true,` 移除。
4. 修改` packages/cherry-markdown/CHANGLOG.md` 头部为
```
# Change Log

## 0.8.58

### Patch Changes
```