### PR TITLE
fix(快捷键): 更新快捷键映射以使用标准键名

### DIFF
--- a/packages/cherry-markdown/src/toolbars/hooks/Size.js
+++ b/packages/cherry-markdown/src/toolbars/hooks/Size.js
@@ -31,10 +31,10 @@ export default class Size extends MenuBase {
       { name: this.$cherry.locale.superLarge, noIcon: true, onclick: this.bindSubClick.bind(this, '32') },
     ];
     this.shortKeyMap = {
-      'Alt-1': '12',
-      'Alt-2': '17',
-      'Alt-3': '24',
-      'Alt-4': '32',
+      'Alt-Digit1': '12',
+      'Alt-Digit2': '17',
+      'Alt-Digit3': '24',
+      'Alt-Digit4': '32',
     };
     this.shortcutKeyMap = {
       [`${ALT_KEY}-${getKeyCode(1)}`]: {


### PR DESCRIPTION
将快捷键映射调整,主要解决size的快捷建一直是17的问题