### PR TITLE
fix: update draw.io resource path configuration

### DIFF
--- a/examples/assets/scripts/drawio-demo.js
+++ b/examples/assets/scripts/drawio-demo.js
@@ -14,7 +14,9 @@
 	var bundle = mxResources.getDefaultBundle(mxLanguage);
 	
 	// Fixes possible asynchronous requests
-	mxUtils.getAll([bundle, './drawio_demo/theme/default.xml'], function(xhr)
+  // 使用相对于HTML文件的正确路径
+  var themeFile = './assets/drawio_lib/default.xml';
+  mxUtils.getAll([bundle, themeFile], function (xhr)
 	{
 		// Adds bundle text to resources
 		mxResources.parse(xhr[0].getText());

--- a/examples/drawio_demo.html
+++ b/examples/drawio_demo.html
@@ -5,8 +5,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>draw.io demo</title>
-    <link rel="stylesheet" href="./assets/drawio_lib/grapheditor.css">
-    <!-- <link rel="stylesheet" href="https://jgraph.github.io/drawio/src/main/webapp/mxgraph/css/common.css"> -->
+  <link rel="stylesheet" href="./assets/drawio_lib/grapheditor.css">
+  <!-- 手动加载mxgraph的CSS文件，避免mxClient.js中的路径问题 -->
+  <link rel="stylesheet" href="./assets/mxgraph/css/common.css">
+  <!-- 配置draw.io的全局变量，在Init.js加载之前设置 -->
+  <script>
+    // 设置正确的路径配置，覆盖Init.js中的默认值
+    window.EXPORT_URL = './assets/drawio_lib';
+    window.SAVE_URL = './assets/drawio_lib';
+    window.OPEN_URL = './assets/drawio_lib';
+    window.RESOURCES_PATH = './assets/drawio_lib/resources';
+    window.STENCIL_PATH = './assets/drawio_lib/image/stencils';
+    window.IMAGE_PATH = './assets/drawio_lib/image';
+    window.STYLE_PATH = './assets/drawio_lib/src/css';
+    window.CSS_PATH = './assets/drawio_lib/src/css';
+    window.OPEN_FORM = './assets/drawio_lib';
+    window.mxBasePath = './assets/drawio_lib/src';
+
+    // 禁用mxClient.js自动加载CSS，因为我们手动加载了
+    window.mxLoadStylesheets = false;
+  </script>
 </head>
 
 <!-- geEditor 是draw.io需要的class -->


### PR DESCRIPTION
Fixed #1218

---

抱歉，本次 PR 同 #1232 ，原因是本地开新分支的时候错误的完全同步了上游仓库，#1232 的分支随即触发了强制推送并关闭 PR

本次 PR 内容与 #1232 一致，可以直接 approve

---

在部署到生产环境（https://tencent.github.io/cherry-markdown/examples/index.html）后发现 draw.io 功能无法正常工作，iframe 显示 "Error loading resource files. Please check browser console." 错误信息。（而在 本地开发环境 是正常的）

推测本地开发环境和部署环境的路径解析方式不同导致的资源路径错误。

---

2025犀牛鸟
