### PR TITLE
fix: #1108 优化粘贴处理逻辑以支持来自 Word 的内容

### DIFF
--- a/.changeset/fix-paste-from-word.md
+++ b/.changeset/fix-paste-from-word.md
@@ -1,0 +1,5 @@
+---
+"cherry-markdown": patch
+---
+
+fix: 优化粘贴处理逻辑以支持来自 Word 的内容

--- a/packages/cherry-markdown/src/Editor.js
+++ b/packages/cherry-markdown/src/Editor.js
@@ -311,18 +311,10 @@ export default class Editor {
 
     // 优先处理来自 Word 等应用的粘贴内容
     // 有效的内容通常由 StartFragment 和 EndFragment 标记包裹。
-    const startFragment = '<!--StartFragment-->';
-    const endFragment = '<!--EndFragment-->';
-    if (html.includes(startFragment)) {
-      const startIndex = html.indexOf(startFragment) + startFragment.length;
-      const endIndex = html.indexOf(endFragment);
+    html = html.replace(/^[\s\S]*<!--StartFragment-->|<!--EndFragment-->[\s\S]*$/g, '');
 
-      if (endIndex > startIndex) {
-        html = html.substring(startIndex, endIndex);
-      }
-    } else {
-      html = html.replace(/<!--[^>]+>/g, '');
-    }
+    // 删除其他无关的注释
+    html = html.replace(/<!--[^>]+>/g, '');
     /**
      * 处理“右键复制图片”场景
      * 在这种场景下，我们希望粘贴进来的图片可以走文件上传逻辑，所以当检测到这种场景后，我们会清空html

--- a/packages/cherry-markdown/src/Editor.js
+++ b/packages/cherry-markdown/src/Editor.js
@@ -308,8 +308,21 @@ export default class Editor {
     }
     let html = clipboardData.getData('Text/Html');
     const { items } = clipboardData;
-    // 清空注释
-    html = html.replace(/<!--[^>]+>/g, '');
+
+    // 优先处理来自 Word 等应用的粘贴内容
+    // 有效的内容通常由 StartFragment 和 EndFragment 标记包裹。
+    const startFragment = '<!--StartFragment-->';
+    const endFragment = '<!--EndFragment-->';
+    if (html.includes(startFragment)) {
+      const startIndex = html.indexOf(startFragment) + startFragment.length;
+      const endIndex = html.indexOf(endFragment);
+
+      if (endIndex > startIndex) {
+        html = html.substring(startIndex, endIndex);
+      }
+    } else {
+      html = html.replace(/<!--[^>]+>/g, '');
+    }
     /**
      * 处理“右键复制图片”场景
      * 在这种场景下，我们希望粘贴进来的图片可以走文件上传逻辑，所以当检测到这种场景后，我们会清空html


### PR DESCRIPTION
fix #1108 

---

我去看了下从 word 里面复制出来的完整的的 text/html 内容，发现 word 中的有效的文本内容都夹在 `<!--StartFragment-->` 与 `<!--EndFragment-->` 之间，所以以此来滤下其他的元数据

可以在[这边](https://evercoder.github.io/clipboard-inspector/)看到粘贴板中的完整数据