### PR TITLE
fix: #1063 修复工具栏的位置错误

### DIFF
--- a/.changeset/fix-toolbar-layout.md
+++ b/.changeset/fix-toolbar-layout.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 调整布局，修复工具栏的位置错误

--- a/.changeset/fix-toolbar-layout.md
+++ b/.changeset/fix-toolbar-layout.md
@@ -2,4 +2,4 @@
 'cherry-markdown': patch
 ---
 
-fix: 调整布局，修复工具栏的位置错误
+fix: 修复工具栏的位置错误

--- a/packages/cherry-markdown/src/Cherry.js
+++ b/packages/cherry-markdown/src/Cherry.js
@@ -183,13 +183,19 @@ export default class Cherry extends CherryStatic {
 
     const wrapperFragment = document.createDocumentFragment();
     wrapperFragment.appendChild(this.toolbar.options.dom);
-    wrapperFragment.appendChild(editor.options.editorDom);
+
+    const contentContainer = document.createElement('div');
+    contentContainer.className = 'cherry-content';
+
+    contentContainer.appendChild(editor.options.editorDom);
     if (!this.options.previewer.dom) {
-      wrapperFragment.appendChild(previewer.options.previewerDom);
+      contentContainer.appendChild(previewer.options.previewerDom);
     }
-    wrapperFragment.appendChild(previewer.options.virtualDragLineDom);
-    wrapperFragment.appendChild(previewer.options.editorMaskDom);
-    wrapperFragment.appendChild(previewer.options.previewerMaskDom);
+    contentContainer.appendChild(previewer.options.virtualDragLineDom);
+    contentContainer.appendChild(previewer.options.editorMaskDom);
+    contentContainer.appendChild(previewer.options.previewerMaskDom);
+
+    wrapperFragment.appendChild(contentContainer);
 
     wrapperDom.appendChild(wrapperFragment);
     this.wrapperDom = wrapperDom;

--- a/packages/cherry-markdown/src/Cherry.js
+++ b/packages/cherry-markdown/src/Cherry.js
@@ -183,19 +183,13 @@ export default class Cherry extends CherryStatic {
 
     const wrapperFragment = document.createDocumentFragment();
     wrapperFragment.appendChild(this.toolbar.options.dom);
-
-    const contentContainer = document.createElement('div');
-    contentContainer.className = 'cherry-content';
-
-    contentContainer.appendChild(editor.options.editorDom);
+    wrapperFragment.appendChild(editor.options.editorDom);
     if (!this.options.previewer.dom) {
-      contentContainer.appendChild(previewer.options.previewerDom);
+      wrapperFragment.appendChild(previewer.options.previewerDom);
     }
-    contentContainer.appendChild(previewer.options.virtualDragLineDom);
-    contentContainer.appendChild(previewer.options.editorMaskDom);
-    contentContainer.appendChild(previewer.options.previewerMaskDom);
-
-    wrapperFragment.appendChild(contentContainer);
+    wrapperFragment.appendChild(previewer.options.virtualDragLineDom);
+    wrapperFragment.appendChild(previewer.options.editorMaskDom);
+    wrapperFragment.appendChild(previewer.options.previewerMaskDom);
 
     wrapperDom.appendChild(wrapperFragment);
     this.wrapperDom = wrapperDom;

--- a/packages/cherry-markdown/src/Cherry.js
+++ b/packages/cherry-markdown/src/Cherry.js
@@ -231,6 +231,11 @@ export default class Cherry extends CherryStatic {
     this.$event.on('editorOpen', () => {
       this.status.editor = 'show';
     });
+    this.$event.on('editor.size.change', () => {
+      // 更新工具栏高度CSS变量
+      const toolbarHeight = this.toolbar.options.dom.offsetHeight;
+      this.wrapperDom.style.setProperty('--height-toolbar', `${toolbarHeight}px`);
+    });
 
     // 切换模式，有纯预览模式、纯编辑模式、双栏编辑模式
     this.switchModel(this.options.editor.defaultModel, this.options.toolbars.showToolbar);

--- a/packages/cherry-markdown/src/Previewer.js
+++ b/packages/cherry-markdown/src/Previewer.js
@@ -149,6 +149,12 @@ export default class Previewer {
     });
     // 开始监听元素
     resizeObserver.observe(this.$cherry.wrapperDom);
+
+    const toolbarObserver = new ResizeObserver(() => {
+      const toolbarHeight = this.$cherry.toolbar.options.dom.offsetHeight;
+      this.$cherry.wrapperDom.style.setProperty('--height-toolbar', `${toolbarHeight}px`);
+    });
+    toolbarObserver.observe(this.$cherry.toolbar.options.dom);
   }
 
   subMenusPositionChange() {

--- a/packages/cherry-markdown/src/Previewer.js
+++ b/packages/cherry-markdown/src/Previewer.js
@@ -149,12 +149,6 @@ export default class Previewer {
     });
     // 开始监听元素
     resizeObserver.observe(this.$cherry.wrapperDom);
-
-    const toolbarObserver = new ResizeObserver(() => {
-      const toolbarHeight = this.$cherry.toolbar.options.dom.offsetHeight;
-      this.$cherry.wrapperDom.style.setProperty('--height-toolbar', `${toolbarHeight}px`);
-    });
-    toolbarObserver.observe(this.$cherry.toolbar.options.dom);
   }
 
   subMenusPositionChange() {

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -16,18 +16,24 @@
 // 主要布局控制，可以不合并进下面的区块
 .cherry {
   display: flex;
-  flex-flow: row wrap;
+  flex-direction: column;
   align-items: stretch;
-  align-content: flex-start;
   height: 100%;
   min-height: 60px;
   position: relative;
   // overflow: hidden;
 
+  .cherry-content {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+  }
+
   .cherry-editor,
   .cherry-previewer {
-    max-height: calc(100% - var(--height-toolbar));
-    min-height: calc(100% - var(--height-toolbar));
+    flex: 1;
+    min-height: 0;
+    max-height: none;
   }
 
   .CodeMirror {
@@ -170,7 +176,7 @@
   min-height: var(--toolbar-height);
   font-size: var(--toolbar-font-size);
   line-height: 2.8;
-  flex-basis: 100%;
+  flex-shrink: 0;
   box-sizing: border-box;
   z-index: 2;
   user-select: none;

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -16,24 +16,18 @@
 // 主要布局控制，可以不合并进下面的区块
 .cherry {
   display: flex;
-  flex-direction: column;
+  flex-flow: row wrap;
   align-items: stretch;
+  align-content: flex-start;
   height: 100%;
   min-height: 60px;
   position: relative;
   // overflow: hidden;
 
-  .cherry-content {
-    display: flex;
-    flex: 1;
-    min-height: 0;
-  }
-
   .cherry-editor,
   .cherry-previewer {
-    flex: 1;
-    min-height: 0;
-    max-height: none;
+    max-height: calc(100% - var(--height-toolbar));
+    min-height: calc(100% - var(--height-toolbar));
   }
 
   .CodeMirror {
@@ -173,10 +167,9 @@
   align-items: baseline;
   justify-content: space-between;
   padding: var(--toolbar-padding);
-  min-height: var(--toolbar-height);
   font-size: var(--toolbar-font-size);
   line-height: 2.8;
-  flex-shrink: 0;
+  flex-basis: 100%;
   box-sizing: border-box;
   z-index: 2;
   user-select: none;
@@ -209,7 +202,6 @@
   .toolbar-right {
     display: flex;
     align-items: center;
-    min-height: var(--toolbar-height);
     flex-wrap: wrap;
     flex: 1;
   }

--- a/packages/cherry-markdown/src/sass/variables/semantic.scss
+++ b/packages/cherry-markdown/src/sass/variables/semantic.scss
@@ -22,8 +22,7 @@
   /* ========== 工具栏相关 ========== */
   --toolbar-bg: var(--oc-white);
   --toolbar-border: var(--base-border-color);
-  --toolbar-height: var(--height-toolbar);
-  --toolbar-padding: 0 var(--spacing-xl);
+  --toolbar-padding: var(--spacing-xs) var(--spacing-xl);
   --toolbar-font-size: var(--font-size-sm);
   --toolbar-radius: none;
   --toolbar-shadow: var(--shadow-md);


### PR DESCRIPTION
fix #1063 

---

目前的工具栏高度直接由屏幕宽度自行决定，不再再受 `--toolbar-height` 控制（该变量已删除）。

而使用变量 `--height-toolbar` 来监视工具栏的高度，

```javascript
const toolbarObserver = new ResizeObserver(() => {
  const toolbarHeight = this.$cherry.toolbar.options.dom.offsetHeight;
    this.$cherry.wrapperDom.style.setProperty('--height-toolbar', `${toolbarHeight}px`);
  });
toolbarObserver.observe(this.$cherry.toolbar.options.dom);
```


该变量仅用于工具栏下方的编辑区和预览区的高度控制

```scss
.cherry-editor,
.cherry-previewer {
  max-height: calc(100% - var(--height-toolbar));
  min-height: calc(100% - var(--height-toolbar));
}
```