### PR TITLE
style:工具栏颜色选择器样式优化

### DIFF
--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -913,15 +913,23 @@
   }
 
   .cherry-color-item {
-    float: left;
+   float: left;
     width: 14px;
     height: 14px;
-    border: 1px solid var(--toolbar-btn-hover-bg);
+    border: 1px solid var(--toolbar-bg);
     cursor: pointer;
+    box-shadow: inset 0 0 0 1px var(--toolbar-btn-hover-bg); /* 内边框 */
 
     &:hover {
       border-color: var(--primary-color);
+      animation: jelly-scale 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
     }
+
+    @keyframes jelly-scale {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+  }
   }
 }
 


### PR DESCRIPTION
【实践issue】工具栏颜色选择器样式优化

代码修改

在 packages\cherry-markdown\src\sass\cherry.scss 中对 .cherry-color-item 进行了修改

1.美化颜色选择器样式

- 修改的颜色选择器的样式 & 对不同样式进行的兼容/优化
```
    .cherry-color-item {
        float: left;
        width: 14px;
        height: 14px;
        /* 外边框 修改了颜色，将颜色选定为与背景色相同的颜色*/
        border: 1px solid var(--toolbar-bg);
        cursor: pointer;
        /* 内边框颜色设置为鼠标悬浮 button 时候的颜色，增强对比色 */
        box-shadow: inset 0 0 0 1px var(--toolbar-btn-hover-bg); 
      }
 ```

源码中将外边距颜色设定为 --toolbar-btn-hover-bg，修改后将外边距颜色设定为 --toolbar-bg 并且添加了内边距 --toolbar-btn-hover-bg 使颜色之间有一定距离，排布清晰。

2.颜色选择器hover样式修改
```
    .cherry-color-item {
        &:hover {
          border-color: var(--primary-color);
          /* 设置了动态效果 效果时间持续0.6s */
          animation: jelly-scale 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
        }
    	/* 定义动态效果放大比例，由原本大小放大1.2倍后再变回原本模样，类似于果冻动态效果 */
        @keyframes jelly-scale {
        0% { transform: scale(1); }
        50% { transform: scale(1.2); }
        100% { transform: scale(1); }
      }
      }
    }
```

添加了果冻缩放的动态效果，使选择颜色的时候更加清晰明了。