### PR TITLE
style: 优化信息面板在各主题下的样式

### DIFF
--- a/packages/cherry-markdown/src/sass/markdown.scss
+++ b/packages/cherry-markdown/src/sass/markdown.scss
@@ -618,9 +618,7 @@ div[data-type='codeBlock'] {
   overflow: hidden;
   border-radius: var(--radius-xl);
   box-sizing: border-box;
-  border: 0.5px solid;
   .cherry-panel--title {
-    color: #fff;
     padding: 5px 20px;
     &.cherry-panel--title__not-empty::before {
       font-family: 'ch-icon';
@@ -633,50 +631,55 @@ div[data-type='codeBlock'] {
   }
 }
 .cherry-panel__primary {
-  background-color: #cfe2ff;
+  border-left: 10px solid #cfe2ff;
+  background-color: var(--md-panel-bg);
   color: #0a58ca;
   .cherry-panel--title {
-    background-color: #0d6dfe;
+    font-weight: 600;
     &.cherry-panel--title__not-empty::before {
       content: '\EA6A';
     }
   }
 }
 .cherry-panel__info {
-  background-color: #cff4fc;
+  border-left: 10px solid #cff4fc;
+  background-color: var(--md-panel-bg);
   color: #087990;
   .cherry-panel--title {
-    background-color: #099cba;
+    font-weight: 600;
     &.cherry-panel--title__not-empty::before {
       content: '\EA69';
     }
   }
 }
 .cherry-panel__warning {
-  background-color: #fff3cd;
+  border-left: 10px solid #fff3cd;
+  background-color: var(--md-panel-bg);
   color: #997404;
   .cherry-panel--title {
-    background-color: #b38806;
+    font-weight: 600;
     &.cherry-panel--title__not-empty::before {
       content: '\EA6B';
     }
   }
 }
 .cherry-panel__danger {
-  background-color: #f8d7da;
+  border-left: 10px solid #f8d7da;
+  background-color: var(--md-panel-bg);
   color: #b02a37;
   .cherry-panel--title {
-    background-color: #dc3545;
+    font-weight: 600;
     &.cherry-panel--title__not-empty::before {
       content: '\EA68';
     }
   }
 }
 .cherry-panel__success {
-  background-color: #d1e7dd;
+  border-left: 10px solid #d1e7dd;
+  background-color: var(--md-panel-bg);
   color: #146c43;
   .cherry-panel--title {
-    background-color: #198754;
+    font-weight: 600;
     &.cherry-panel--title__not-empty::before {
       content: '\EA67';
     }

--- a/packages/cherry-markdown/src/sass/themes/blue.scss
+++ b/packages/cherry-markdown/src/sass/themes/blue.scss
@@ -43,6 +43,7 @@
   --md-blockquote-bg: var(--oc-violet-1);
   --md-hr-border: var(--oc-indigo-4);
   --md-table-border: var(--oc-indigo-4);
+  --md-panel-bg: var( --oc-white);
 }
 
 /** 预览区域样式 */

--- a/packages/cherry-markdown/src/sass/themes/dark.scss
+++ b/packages/cherry-markdown/src/sass/themes/dark.scss
@@ -46,6 +46,7 @@
   --md-blockquote-bg: rgba(102, 128, 153, 0.05);
   --md-hr-border: var(--oc-gray-5);
   --md-table-border: var(--oc-gray-5);
+  --md-panel-bg: var(--oc-gray-3);
 
   /* 目录区域样式 */
   .cherry-flex-toc {

--- a/packages/cherry-markdown/src/sass/themes/default.scss
+++ b/packages/cherry-markdown/src/sass/themes/default.scss
@@ -42,6 +42,7 @@
   --md-blockquote-bg: rgba(134, 142, 150, 0.05);
   --md-hr-border: var(--oc-gray-3);
   --md-table-border: var(--oc-gray-3);
+  --md-panel-bg: var( --oc-white);
 }
 
 /** 预览区域样式 */

--- a/packages/cherry-markdown/src/sass/themes/green.scss
+++ b/packages/cherry-markdown/src/sass/themes/green.scss
@@ -44,6 +44,7 @@
   --md-blockquote-bg: var(--oc-green-1);
   --md-hr-border: var(--oc-green-8);
   --md-table-border: var(--oc-green-8);
+  --md-panel-bg: var( --oc-white);
 }
 
 /** 预览区域样式 */

--- a/packages/cherry-markdown/src/sass/themes/light.scss
+++ b/packages/cherry-markdown/src/sass/themes/light.scss
@@ -42,4 +42,5 @@
   --md-blockquote-bg: var(--oc-blue-0);
   --md-hr-border: var(--oc-blue-5);
   --md-table-border: var(--oc-blue-5);
+  --md-panel-bg: var( --oc-white);
 }

--- a/packages/cherry-markdown/src/sass/themes/red.scss
+++ b/packages/cherry-markdown/src/sass/themes/red.scss
@@ -43,6 +43,7 @@
   --md-blockquote-bg: var(--oc-pink-1);
   --md-hr-border: var(--oc-pink-8);
   --md-table-border: var(--oc-pink-8);
+  --md-panel-bg: var( --oc-white);
 }
 
 /** 预览区域样式 */

--- a/packages/cherry-markdown/src/sass/themes/violet.scss
+++ b/packages/cherry-markdown/src/sass/themes/violet.scss
@@ -41,6 +41,7 @@
   --md-blockquote-bg: var(--oc-violet-1);
   --md-hr-border: var(--oc-violet-8);
   --md-table-border: var(--oc-violet-8);
+  --md-panel-bg: var( --oc-white);
 }
 
 /** 预览区域样式 */


### PR DESCRIPTION
【实践issue】优化信息面板在各主题下的样式 #1220

对信息面板在各主题下的样式进行重构优化:

1. 变更内容

    - 优化信息面板图标和标题的展示
    - 重新设计信息面板的样式
    - 针对暗黑主题定制不同风格的样式

2. 变更影响

    -  提升了信息面板在各主题下的视觉表现,整体样式更加简洁精致

3. 效果展示
<img width="1185" height="885" alt="ae65e33e121c966972fc74f682b9ef2" src="https://github.com/user-attachments/assets/9990d5ef-555e-4f0f-8014-3b6e64ca020a" />
