### PR TITLE
style：优化目录语法在各主题下的样式

### DIFF
--- a/packages/cherry-markdown/src/sass/markdown.scss
+++ b/packages/cherry-markdown/src/sass/markdown.scss
@@ -29,55 +29,12 @@
   .h1 small,
   .h2 small,
   .h3 small,
-  .h4 small,
-  .h5 small,
-  .h6 small,
-  h1 .small,
-  h2 .small,
-  h3 .small,
-  h4 .small,
-  h5 .small,
-  h6 .small,
-  .h1 .small,
-  .h2 .small,
-  .h3 .small,
-  .h4 .small,
-  .h5 .small,
-  .h6 .small {
-    font-weight: normal;
-    line-height: 1;
-    color: var(--oc-gray-5);
-  }
-
-  h1,
-  h2,
-  h3 {
-    margin-top: 30px;
-    margin-bottom: var(--spacing-lg);
-  }
-
-  h1 small,
-  h2 small,
-  h3 small,
-  h1 .small,
-  h2 .small,
-  h3 .small {
-    font-size: 65%;
-  }
-
-  h4,
-  h5,
-  h6 {
-    margin-top: var(--spacing-md);
-    margin-bottom: var(--spacing-md);
-  }
-
   h4 small,
   h5 small,
   h6 small,
   h4 .small,
-  h5 .small,
-  h6 .small {
+  h5 small,
+  h6 small {
     font-size: 75%;
   }
 
@@ -305,24 +262,129 @@
   }
 
   .toc {
+    // 基础布局样式
     margin-bottom: var(--spacing-lg);
     padding-left: 0;
+    
+    // 现代化样式 - 基础结构
+    border-radius: 16px;
+    padding: 20px;
+    margin: 24px 0;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    overflow: hidden;
+    backdrop-filter: blur(10px);
+
+    // 顶部装饰条
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      border-radius: 16px 16px 0 0;
+    }
+
+    // 悬停效果
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08), 0 2px 6px rgba(0, 0, 0, 0.12);
+    }
 
     .toc-title {
-      font-size: var(--font-size-2xl);
-      margin-bottom: 5px;
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--md-heading-color);
+      margin-bottom: 16px;
+      text-align: center;
+      position: relative;
+      padding-bottom: 8px;
+      letter-spacing: 0.5px;
+
+      &::after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 30px;
+        height: 2px;
+        border-radius: 1px;
+      }
     }
 
     .toc-li {
       border: none;
       list-style: none;
+      margin: 4px 0;
+      transition: all 0.2s ease;
 
       a {
+        display: block;
+        padding: 8px 14px;
+        border-radius: 6px;
         text-decoration: none;
         color: var(--md-paragraph-color);
+        transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+        position: relative;
+        border-left: 2px solid transparent;
+        font-size: 0.9rem;
+        line-height: 1.4;
 
         &:hover {
-          color: var(--md-link-hover-color);
+          color: var(--primary-color);
+          border-left-color: var(--primary-color);
+          transform: translateX(3px);
+        }
+
+        // 层级样式
+        &.level-1 {
+          font-weight: 600;
+          font-size: 1rem;
+          margin-left: 0;
+          padding: 10px 14px;
+        }
+
+        &.level-2 {
+          font-weight: 500;
+          font-size: 0.9rem;
+          margin-left: 16px;
+          opacity: 0.9;
+          padding: 7px 12px;
+        }
+
+        &.level-3 {
+          font-weight: 400;
+          font-size: 0.85rem;
+          margin-left: 32px;
+          opacity: 0.8;
+          padding: 6px 10px;
+        }
+
+        &.level-4 {
+          font-weight: 400;
+          font-size: 0.8rem;
+          margin-left: 48px;
+          opacity: 0.7;
+          padding: 5px 8px;
+        }
+
+        &.level-5 {
+          font-weight: 400;
+          font-size: 0.75rem;
+          margin-left: 64px;
+          opacity: 0.6;
+          padding: 4px 6px;
+        }
+
+        &.level-6 {
+          font-weight: 400;
+          font-size: 0.7rem;
+          margin-left: 80px;
+          opacity: 0.5;
+          padding: 3px 4px;
         }
       }
     }

--- a/packages/cherry-markdown/src/sass/themes/blue.scss
+++ b/packages/cherry-markdown/src/sass/themes/blue.scss
@@ -60,16 +60,33 @@
 
   /** 目录 */
   .toc {
-    border-bottom: 1px solid var(--md-hr-border);
-    padding-bottom: 15px;
-    margin-bottom: 30px;
+    // 主题特定的背景和边框
+    background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(99, 102, 241, 0.08));
+    border: 1px solid rgba(79, 70, 229, 0.25);
+    box-shadow: 0 2px 12px rgba(79, 70, 229, 0.15), 0 1px 3px rgba(79, 70, 229, 0.1);
+
+    &::before {
+      background: linear-gradient(90deg, var(--oc-indigo-6), var(--oc-indigo-5), var(--oc-blue-5));
+    }
+
+    &:hover {
+      background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(99, 102, 241, 0.12));
+      box-shadow: 0 4px 20px rgba(79, 70, 229, 0.2), 0 2px 6px rgba(79, 70, 229, 0.15);
+    }
 
     .toc-title {
-      text-align: center;
-      padding-bottom: 15px;
-      margin-top: 30px;
-      margin-bottom: 15px;
-      border-bottom: 1px solid var(--md-hr-border);
+      &::after {
+        background: linear-gradient(90deg, var(--oc-indigo-6), var(--oc-indigo-5));
+      }
+    }
+
+    .toc-li {
+      a {
+        &:hover {
+          background: rgba(79, 70, 229, 0.15);
+          box-shadow: 0 1px 4px rgba(79, 70, 229, 0.2);
+        }
+      }
     }
   }
 }

--- a/packages/cherry-markdown/src/sass/themes/dark.scss
+++ b/packages/cherry-markdown/src/sass/themes/dark.scss
@@ -123,19 +123,33 @@
 .cherry-markdown.theme__dark {
   /** 目录 */
   .toc {
-    border: 1px solid var(--md-hr-border);
-    margin-top: 15px;
-    margin-bottom: 15px;
-    margin-right: 15px;
+    // 主题特定的背景和边框
+    background: linear-gradient(135deg, rgba(251, 146, 60, 0.08), rgba(251, 191, 36, 0.08));
+    border: 1px solid rgba(251, 146, 60, 0.25);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.2);
+
+    &::before {
+      background: linear-gradient(90deg, var(--primary-color), var(--oc-orange-4), var(--oc-yellow-4));
+    }
+
+    &:hover {
+      background: linear-gradient(135deg, rgba(251, 146, 60, 0.12), rgba(251, 191, 36, 0.12));
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2), 0 2px 6px rgba(0, 0, 0, 0.25);
+    }
 
     .toc-title {
-      padding: 15px;
-      margin-bottom: 15px;
-      border-bottom: 1px solid var(--md-hr-border);
+      &::after {
+        background: linear-gradient(90deg, var(--primary-color), var(--oc-orange-4));
+      }
     }
 
     .toc-li {
-      padding: 0 20px;
+      a {
+        &:hover {
+          background: rgba(251, 146, 60, 0.15);
+          box-shadow: 0 1px 4px rgba(251, 146, 60, 0.2);
+        }
+      }
     }
   }
 

--- a/packages/cherry-markdown/src/sass/themes/default.scss
+++ b/packages/cherry-markdown/src/sass/themes/default.scss
@@ -135,138 +135,31 @@
 
   /** 目录 */
   .toc {
+    // 主题特定的背景和边框
     background: linear-gradient(135deg, rgba(59, 130, 246, 0.03), rgba(147, 51, 234, 0.03));
     border: 1px solid rgba(59, 130, 246, 0.15);
-    border-radius: 16px;
-    padding: 20px;
-    margin: 24px 0;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    position: relative;
-    overflow: hidden;
-    backdrop-filter: blur(10px);
 
     &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 2px;
       background: linear-gradient(90deg, var(--primary-color), var(--oc-blue-4), var(--oc-purple-4));
-      border-radius: 16px 16px 0 0;
     }
 
     &:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08), 0 2px 6px rgba(0, 0, 0, 0.12);
       background: linear-gradient(135deg, rgba(59, 130, 246, 0.05), rgba(147, 51, 234, 0.05));
     }
 
     .toc-title {
-      font-size: 1.1rem;
-      font-weight: 600;
-      color: var(--md-heading-color);
-      margin-bottom: 16px;
-      text-align: center;
-      position: relative;
-      padding-bottom: 8px;
-      letter-spacing: 0.5px;
-
       &::after {
-        content: '';
-        position: absolute;
-        bottom: 0;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 30px;
-        height: 2px;
         background: linear-gradient(90deg, var(--primary-color), var(--oc-blue-4));
-        border-radius: 1px;
       }
     }
 
     .toc-li {
-      margin: 4px 0;
-      transition: all 0.2s ease;
-
       a {
-        display: block;
-        padding: 8px 14px;
-        border-radius: 6px;
-        text-decoration: none;
-        color: var(--md-paragraph-color);
-        transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-        position: relative;
-        border-left: 2px solid transparent;
-        font-size: 0.9rem;
-        line-height: 1.4;
-
         &:hover {
           background: rgba(59, 130, 246, 0.06);
-          color: var(--primary-color);
-          border-left-color: var(--primary-color);
-          transform: translateX(3px);
           box-shadow: 0 1px 4px rgba(59, 130, 246, 0.12);
         }
-
-        &.level-1 {
-          font-weight: 600;
-          font-size: 1rem;
-          margin-left: 0;
-          padding: 10px 14px;
-        }
-
-        &.level-2 {
-          font-weight: 500;
-          font-size: 0.9rem;
-          margin-left: 16px;
-          opacity: 0.9;
-          padding: 7px 12px;
-        }
-
-        &.level-3 {
-          font-weight: 400;
-          font-size: 0.85rem;
-          margin-left: 32px;
-          opacity: 0.8;
-          padding: 6px 10px;
-        }
-
-        &.level-4 {
-          font-weight: 400;
-          font-size: 0.8rem;
-          margin-left: 48px;
-          opacity: 0.7;
-          padding: 5px 8px;
-        }
-
-        &.level-5 {
-          font-weight: 400;
-          font-size: 0.75rem;
-          margin-left: 64px;
-          opacity: 0.6;
-          padding: 4px 6px;
-        }
-
-        &.level-6 {
-          font-weight: 400;
-          font-size: 0.7rem;
-          margin-left: 80px;
-          opacity: 0.5;
-          padding: 3px 4px;
-        }
       }
-    }
-  
-  .toc-title {}
-
-    .toc-li {
-      .level-1 {}
-
-      .level-2 {}
-
-      .level-3 {}
     }
   }
 }

--- a/packages/cherry-markdown/src/sass/themes/green.scss
+++ b/packages/cherry-markdown/src/sass/themes/green.scss
@@ -59,16 +59,33 @@
 
   /** 目录 */
   .toc {
-    border-bottom: 1px solid var(--md-hr-border);
-    padding-bottom: 15px;
-    margin-bottom: 30px;
+    // 主题特定的背景和边框
+    background: linear-gradient(135deg, rgba(34, 197, 94, 0.08), rgba(16, 185, 129, 0.08));
+    border: 1px solid rgba(34, 197, 94, 0.25);
+    box-shadow: 0 2px 12px rgba(34, 197, 94, 0.15), 0 1px 3px rgba(34, 197, 94, 0.1);
+
+    &::before {
+      background: linear-gradient(90deg, var(--oc-green-6), var(--oc-green-5), var(--oc-emerald-5));
+    }
+
+    &:hover {
+      background: linear-gradient(135deg, rgba(34, 197, 94, 0.12), rgba(16, 185, 129, 0.12));
+      box-shadow: 0 4px 20px rgba(34, 197, 94, 0.2), 0 2px 6px rgba(34, 197, 94, 0.15);
+    }
 
     .toc-title {
-      text-align: center;
-      padding-bottom: 15px;
-      margin-top: 30px;
-      margin-bottom: 15px;
-      border-bottom: 1px solid var(--md-hr-border);
+      &::after {
+        background: linear-gradient(90deg, var(--oc-green-6), var(--oc-green-5));
+      }
+    }
+
+    .toc-li {
+      a {
+        &:hover {
+          background: rgba(34, 197, 94, 0.15);
+          box-shadow: 0 1px 4px rgba(34, 197, 94, 0.2);
+        }
+      }
     }
   }
 }

--- a/packages/cherry-markdown/src/sass/themes/light.scss
+++ b/packages/cherry-markdown/src/sass/themes/light.scss
@@ -43,3 +43,38 @@
   --md-hr-border: var(--oc-blue-5);
   --md-table-border: var(--oc-blue-5);
 }
+
+/** 预览区域样式 */
+.cherry-markdown.theme__light {
+  /** 目录 */
+  .toc {
+    // 主题特定的背景和边框
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(59, 130, 246, 0.08));
+    border: 1px solid rgba(37, 99, 235, 0.25);
+    box-shadow: 0 2px 12px rgba(37, 99, 235, 0.15), 0 1px 3px rgba(37, 99, 235, 0.1);
+
+    &::before {
+      background: linear-gradient(90deg, var(--oc-blue-6), var(--oc-blue-5), var(--oc-cyan-5));
+    }
+
+    &:hover {
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.12));
+      box-shadow: 0 4px 20px rgba(37, 99, 235, 0.2), 0 2px 6px rgba(37, 99, 235, 0.15);
+    }
+
+    .toc-title {
+      &::after {
+        background: linear-gradient(90deg, var(--oc-blue-6), var(--oc-blue-5));
+      }
+    }
+
+    .toc-li {
+      a {
+        &:hover {
+          background: rgba(37, 99, 235, 0.15);
+          box-shadow: 0 1px 4px rgba(37, 99, 235, 0.2);
+        }
+      }
+    }
+  }
+}

--- a/packages/cherry-markdown/src/sass/themes/red.scss
+++ b/packages/cherry-markdown/src/sass/themes/red.scss
@@ -60,16 +60,33 @@
 
   /** 目录 */
   .toc {
-    border-bottom: 1px solid var(--md-hr-border);
-    padding-bottom: 15px;
-    margin-bottom: 30px;
+    // 主题特定的背景和边框
+    background: linear-gradient(135deg, rgba(236, 72, 153, 0.08), rgba(244, 114, 182, 0.08));
+    border: 1px solid rgba(236, 72, 153, 0.25);
+    box-shadow: 0 2px 12px rgba(236, 72, 153, 0.15), 0 1px 3px rgba(236, 72, 153, 0.1);
+
+    &::before {
+      background: linear-gradient(90deg, var(--oc-pink-7), var(--oc-pink-6), var(--oc-red-5));
+    }
+
+    &:hover {
+      background: linear-gradient(135deg, rgba(236, 72, 153, 0.12), rgba(244, 114, 182, 0.12));
+      box-shadow: 0 4px 20px rgba(236, 72, 153, 0.2), 0 2px 6px rgba(236, 72, 153, 0.15);
+    }
 
     .toc-title {
-      text-align: center;
-      padding-bottom: 15px;
-      margin-top: 30px;
-      margin-bottom: 15px;
-      border-bottom: 1px solid var(--md-hr-border);
+      &::after {
+        background: linear-gradient(90deg, var(--oc-pink-7), var(--oc-pink-6));
+      }
+    }
+
+    .toc-li {
+      a {
+        &:hover {
+          background: rgba(236, 72, 153, 0.15);
+          box-shadow: 0 1px 4px rgba(236, 72, 153, 0.2);
+        }
+      }
     }
   }
 }

--- a/packages/cherry-markdown/src/sass/themes/violet.scss
+++ b/packages/cherry-markdown/src/sass/themes/violet.scss
@@ -56,16 +56,33 @@
 
   /** 目录 */
   .toc {
-    border-bottom: 1px solid var(--md-hr-border);
-    padding-bottom: 15px;
-    margin-bottom: 30px;
+      // 主题特定的背景和边框
+      background: linear-gradient(135deg, rgba(139, 92, 246, 0.08), rgba(168, 85, 247, 0.08));
+      border: 1px solid rgba(139, 92, 246, 0.25);
+      box-shadow: 0 2px 12px rgba(139, 92, 246, 0.15), 0 1px 3px rgba(139, 92, 246, 0.1);
 
-    .toc-title {
-      text-align: center;
-      padding-bottom: 15px;
-      margin-top: 30px;
-      margin-bottom: 15px;
-      border-bottom: 1px solid var(--md-hr-border);
-    }
+      &::before {
+        background: linear-gradient(90deg, var(--oc-violet-6), var(--oc-violet-5), var(--oc-purple-5));
+      }
+
+      &:hover {
+        background: linear-gradient(135deg, rgba(139, 92, 246, 0.12), rgba(168, 85, 247, 0.12));
+        box-shadow: 0 4px 20px rgba(139, 92, 246, 0.2), 0 2px 6px rgba(139, 92, 246, 0.15);
+      }
+
+      .toc-title {
+        &::after {
+          background: linear-gradient(90deg, var(--oc-violet-6), var(--oc-violet-5));
+        }
+      }
+
+      .toc-li {
+        a {
+          &:hover {
+            background: rgba(139, 92, 246, 0.15);
+            box-shadow: 0 1px 4px rgba(139, 92, 246, 0.2);
+          }
+        }
+      }
   }
 }


### PR DESCRIPTION
Fixes #1224 

## 改进内容
###  视觉优化
- 现代化设计 ：采用渐变背景、圆角边框、阴影效果
- 装饰性元素 ：添加顶部装饰条和标题下划线
- 层次分明 ：通过不同的字体大小、权重和透明度区分标题层级
- 主题适配 ：每个主题使用对应的主色调，保持整体风格一致
### 交互体验
- 悬停效果 ：鼠标悬停时的背景渐变和阴影增强
- 链接交互 ：目录项悬停时的背景高亮和阴影效果
- 平滑过渡 ：所有交互效果都添加了平滑的过渡动画
###  技术实现
- CSS 变量 ：使用 CSS 自定义属性便于主题切换
- 渐变背景 ：采用线性渐变创造现代感
- 伪元素装饰 ：使用 ::before 和 ::after 添加装饰效果
- 盒阴影 ：多层阴影营造立体感
## 效果展示
default主题：
优化前：
<img width="621" height="790" alt="image" src="https://github.com/user-attachments/assets/3f088497-1b17-4b06-9fe0-494181249e12" />
优化后
<img width="673" height="845" alt="image" src="https://github.com/user-attachments/assets/e36776ba-3d08-4986-b403-9bd137362e17" />

dark主题：
优化前：
<img width="689" height="785" alt="608c32fe590a1aa4df38994c11a9db2f" src="https://github.com/user-attachments/assets/837677d5-5293-4511-bdbe-9b4c7ef9d247" />
优化后
<img width="756" height="838" alt="image" src="https://github.com/user-attachments/assets/50466471-bc8d-4ea2-bf8f-b158838a3c8e" />
