### PR TITLE
feat: 设定各主题下代码块按钮的样式

### DIFF
--- a/packages/cherry-markdown/src/core/hooks/InlineMath.js
+++ b/packages/cherry-markdown/src/core/hooks/InlineMath.js
@@ -34,7 +34,7 @@ export default class InlineMath extends ParagraphBase {
   constructor({ config }) {
     super({ needCache: true });
     // 非浏览器环境下配置为 node
-    this.engine = isBrowser() ? config.engine ?? 'MathJax' : 'node';
+    this.engine = isBrowser() ? (config.engine ?? 'MathJax') : 'node';
   }
 
   toHtml(wholeMatch, leadingChar, m1) {

--- a/packages/cherry-markdown/src/core/hooks/MathBlock.js
+++ b/packages/cherry-markdown/src/core/hooks/MathBlock.js
@@ -34,7 +34,7 @@ export default class MathBlock extends ParagraphBase {
   constructor({ config }) {
     super({ needCache: true });
     // 非浏览器环境下配置为 node
-    this.engine = isBrowser() ? config.engine ?? 'MathJax' : 'node';
+    this.engine = isBrowser() ? (config.engine ?? 'MathJax') : 'node';
   }
 
   toHtml(wholeMatch, lineSpace, leadingChar, content) {

--- a/packages/cherry-markdown/src/utils/cm-search-replace.js
+++ b/packages/cherry-markdown/src/utils/cm-search-replace.js
@@ -424,7 +424,7 @@ export default class SearchBox {
     const cursor = cm.getCursor(position);
     const searchCursor = cm.getSearchCursor(val, cursor, !caseSensitive);
 
-    (next = searchCursor.findNext.bind(searchCursor)), (prev = searchCursor.findPrevious.bind(searchCursor));
+    ((next = searchCursor.findNext.bind(searchCursor)), (prev = searchCursor.findPrevious.bind(searchCursor)));
 
     if (o.backwards && !prev()) {
       is = next();

--- a/packages/cherry-markdown/src/utils/footnoteHoverHandler.js
+++ b/packages/cherry-markdown/src/utils/footnoteHoverHandler.js
@@ -75,7 +75,7 @@ export default class FootnoteHoverHandler {
     this.bubbleCard.content =
       this.previewerDom.querySelector(`.one-footnote[data-index="${this.bubbleCard.refNum}"]`).innerHTML ?? '';
     const previewClassName = this.previewerDom.className ?? '';
-    const themeClass = /theme__[^\s]+/.test(previewClassName) ? previewClassName.match(/theme__[^\s]+/)[0] ?? '' : '';
+    const themeClass = /theme__[^\s]+/.test(previewClassName) ? (previewClassName.match(/theme__[^\s]+/)[0] ?? '') : '';
     this.container.className = `${this.container.className.replace(/(^|\s)theme__[^\s]+/g, '')} ${themeClass}`;
     const customContent =
       this.bubbleConfig?.render(


### PR DESCRIPTION
Resolves #1223

前一次使用了错误的仓库分支，现在基于dev分支重新实现。

现在在各主题下代码块工具栏以及代码mask均使用了合适的样式，以red主题为例：
<img width="1197" height="633" alt="image" src="https://github.com/user-attachments/assets/ac03ced9-210d-4ad5-bfde-858729a9a9a2" />

同时添加了0.3s的展开收起过渡动画

简单演示如下：
https://github.com/user-attachments/assets/3cb47a0d-b095-477c-a574-6dab8409e82c


