### PR TITLE
feat: 重构公式面板的 HTML，优化样式和交互体验

### DIFF
--- a/.changeset/rework-formula-panel-ui.md
+++ b/.changeset/rework-formula-panel-ui.md
@@ -2,4 +2,8 @@
 "@cherry-markdown/cherry-markdown": patch
 ---
 
-feat: 重构公式面板的 HTML 结构，优化样式和交互体验
+refactor: 对公式面板的界面的重构
+
+feat: 公式面板增加“文本样式”页
+
+fix: 修复公式菜单位置计算，防止超出右侧边界

--- a/.changeset/rework-formula-panel-ui.md
+++ b/.changeset/rework-formula-panel-ui.md
@@ -1,0 +1,5 @@
+---
+"@cherry-markdown/cherry-markdown": patch
+---
+
+feat: 重构公式面板的 HTML 结构，优化样式和交互体验

--- a/packages/cherry-markdown/src/sass/bubble_formula.scss
+++ b/packages/cherry-markdown/src/sass/bubble_formula.scss
@@ -1,172 +1,216 @@
 .cherry-insert-formula-wrappler {
-  width: 610px !important; // 覆盖默认.cherry-dropdown样式
-  height: 300px !important;
-  padding: 15px;
+  // 覆盖默认.cherry-dropdown样式
+  width: 680px !important;
+  height: 420px !important;
+  padding: 0 !important;
   display: flex;
   position: fixed !important;
   z-index: 9999999;
-  box-shadow: 0 0.5rem 1rem var(--shadow-color);
+  box-shadow: var(--box-shadow-down);
   box-sizing: border-box;
-  border-radius: 10px;
-  background-color: var(--base-editor-bg) !important;
+  border-radius: 12px;
   overflow: hidden;
+  border: 1px solid var(--base-border-color);
 
-  .cherry-insert-formula-more {
-    position: absolute;
-    bottom: 0;
-    font-size: var(--font-size-xs);
-  }
-
-  .cherry-insert-formula-tabs {
-    width: 100px;
-    height: 100%;
+  ul {
     list-style: none;
-    padding: 10px 0 0 10px;
+    padding: 0;
     margin: 0;
-    margin-right: 10px;
-    .cherry-insert-formula-tab {
-      width: 100%;
-      height: 30px;
-      text-align: center;
-      border: 1px solid var(--base-border-color);
-      border-radius: 5px;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      cursor: pointer;
-      & > a {
-        display: block;
-        text-decoration: none;
-        user-select: none;
-        user-select: none;
-      }
-      &:not(:first-child) {
-        margin-top: 10px;
-      }
-    }
-
-    .cherry-insert-formula-tab.active {
-      color: var(--base-font-color);
-      border: 1px solid var(--primary-color);
-      border-radius: 5px;
-    }
   }
 
-  .cherry-insert-formula-select {
-    height: 100%;
-    flex: 1;
-    display: none;
-    overflow-y: scroll;
+  .cherry-formula-nav {
+    width: 120px;
+    flex-shrink: 0;
+    padding: 8px;
+    border-right: 1px solid var(--base-border-color);
 
-    .cherry-insert-formula-categary {
-        width: 130px;
-        position: relative;
-        &:not(:first-child) {
-          margin-top: 10px;
-          .cherry-insert-formula-categary__func {
-            top: -10px;
-          }
-        }
-        &:hover .cherry-insert-formula-categary__func {
-          display: block;
-        }
-
-      .cherry-insert-formula-categary__func {
-        min-width: 200px;
-        height: 260px;
-        position: absolute;
-        left: 100%;
-        z-index: 100;
-        padding: 0 15px 15px 15px;
-        background-color: var(--base-editor-bg);
-        border: none;
-          box-shadow: none;
-        display: none;
-        overflow-y: scroll;
-
-        .cherry-insert-formula-categary__func-categary {
-          border-top: 1px solid var(--base-border-color);
-          border-bottom: 1px solid var(--base-border-color);
-          margin-bottom: 8px;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
-
-        .cherry-insert-formula-categary__func-item {
-          cursor: pointer;
-          border: 1px solid var(--base-border-color);
-          display: inline-block;
-          text-align: center;
-          background-color: var(--base-editor-bg);
-          margin: 4px;
-          padding: 2px;
-          vertical-align: middle;
-          line-height: 30px;
-          border-color: var(--toolbar-btn-hover-bg);
-          border-radius: 5px;
-
-          &:hover {
-            border-color: var(--toolbar-btn-hover-bg);
-            background-color: var(--toolbar-btn-hover-bg);
-          }
-          svg, img {
-            pointer-events: none;
-          }
-        }
-
-
-      }
-
-      .cherry-insert-formula-categary__btn {
+    .cherry-formula-main-tabs {
+      .cherry-formula-main-tab {
+        padding: 10px 12px;
+        border-radius: 6px;
         cursor: pointer;
-        display: inline-block;
-        font-weight: 400;
-        text-align: center;
-        vertical-align: middle;
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--base-font-color);
         user-select: none;
-        background-color: transparent;
-        border: 1px solid transparent;
-        padding: 0.375rem 0.75rem;
-        font-size: 1rem;
-        line-height: 1.5;
-        border-radius: 0.25rem;
-        width: 100%;
+        transition: background-color 0.2s ease, color 0.2s ease;
 
-        & > img {
-          width: 100%;
-          height: 60%;
+        &:not(:last-child) {
+          margin-bottom: 4px;
+        }
+
+        &.active {
+          background-color: var(--dropdown-item-active-bg);
+          color: var(--dropdown-item-active-color);
         }
 
         &:hover {
-          color: var(--primary-color);
+          background-color: var(--dropdown-item-hover-bg);
+          color: var(--dropdown-item-hover-color);
         }
-
-        &:hover + .cherry-insert-formula-categary__func {
-          float: left;
-          display: block;
-        }
-      }
-
-      .btn-light {
-        color: var(--base-font-color);
-        background-color: var(--base-editor-bg);
-        border-color: var(--base-border-color);
       }
     }
   }
 
-  .cherry-insert-formula-select.active {
-    display: block;
+  .cherry-formula-content-wrapper {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+  }
+
+  .cherry-formula-content {
+    display: none;
+    flex-direction: column;
+    height: 100%;
+
+    &.active {
+      display: flex;
+    }
+  }
+
+  .cherry-formula-sub-nav {
+    padding: 8px 12px;
+    flex-shrink: 0;
+
+    .cherry-formula-sub-tabs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+
+      .cherry-formula-sub-tab {
+        padding: 6px 12px;
+        border-radius: 16px;
+        cursor: pointer;
+        font-size: 13px;
+        color: var(--base-font-color);
+        user-select: none;
+        transition: background-color 0.2s ease, color 0.2s ease;
+
+        &.active {
+          background-color: var(--dropdown-item-active-bg);
+          color: var(--dropdown-item-active-color);
+        }
+
+        &:hover {
+          background-color: var(--dropdown-item-hover-bg);
+          color: var(--dropdown-item-hover-color);
+        }
+      }
+    }
+  }
+
+  .cherry-formula-grid-wrapper {
+    flex-grow: 1;
+    overflow-y: auto;
+    padding: 16px;
+  }
+
+  .cherry-formula-grid {
+    display: none;
+
+    &.active {
+      display: block;
+    }
+  }
+
+  .cherry-formula-grid-group {
+    &:not(:last-child) {
+      margin-bottom: 20px;
+    }
+  }
+
+  .cherry-formula-grid-group-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--base-font-color);
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--base-border-color);
+  }
+
+  .cherry-formula-grid-items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  // Base styles for all items
+  .cherry-formula-item {
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--oc-gray-4);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+    background-color: var(--base-editor-bg);
+
+    &:hover {
+      background-color: var(--dropdown-item-hover-bg);
+      color: var(--dropdown-item-hover-color);
+    }
+
+    svg,
+    img {
+      pointer-events: none;
+    }
+  }
+
+  // "快捷工具"：这边主要是符号一些比较小的 item
+  // 等高，自动换行
+  .cherry-formula-item-light {
+    height: 32px;
+    width: auto;
+    padding: 0 12px;
+    justify-content: center;
+
+    svg,
+    img {
+      height: 50%;
+      width: auto;
+    }
+  }
+
+  // "公式模板"：这边主要是一些较大的公式
+  // 每行一个
+  .cherry-formula-item-large {
+    width: 100%;
+    height: auto;
+    min-height: 48px;
+    padding: 10px 12px;
+    justify-content: center;
+
+    svg,
+    img {
+      height: auto;
+      width: auto;
+      max-width: 100%;
+    }
+  }
+
+  .cherry-insert-formula-more {
+    position: absolute;
+    bottom: 8px;
+    left: 12px;
+    font-size: 12px;
+    color: var(--editor-comment-color);
+
+    a {
+      color: var(--primary-color);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 }
 
 .no-scrollbar {
   -ms-overflow-style: none;
   scrollbar-width: none;
-}
 
-.no-scrollbar::-webkit-scrollbar {
-  display: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/packages/cherry-markdown/src/sass/bubble_formula.scss
+++ b/packages/cherry-markdown/src/sass/bubble_formula.scss
@@ -23,6 +23,7 @@
     flex-shrink: 0;
     padding: 8px;
     border-right: 1px solid var(--base-border-color);
+    position: relative;
 
     .cherry-formula-main-tabs {
       .cherry-formula-main-tab {
@@ -47,6 +48,25 @@
         &:hover {
           background-color: var(--dropdown-item-hover-bg);
           color: var(--dropdown-item-hover-color);
+        }
+      }
+    }
+
+    .cherry-insert-formula-more {
+      position: absolute;
+      bottom: 8px;
+      left: 50%;
+      transform: translateX(-50%);
+      font-size: 12px;
+      color: var(--editor-comment-color);
+      white-space: nowrap;
+
+      a {
+        color: var(--primary-color);
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
         }
       }
     }
@@ -184,23 +204,6 @@
       height: auto;
       width: auto;
       max-width: 100%;
-    }
-  }
-
-  .cherry-insert-formula-more {
-    position: absolute;
-    bottom: 8px;
-    left: 12px;
-    font-size: 12px;
-    color: var(--editor-comment-color);
-
-    a {
-      color: var(--primary-color);
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
     }
   }
 }

--- a/packages/cherry-markdown/src/sass/bubble_formula.scss
+++ b/packages/cherry-markdown/src/sass/bubble_formula.scss
@@ -159,14 +159,13 @@
   // "快捷工具"：这边主要是符号一些比较小的 item
   // 等高，自动换行
   .cherry-formula-item-light {
-    height: 32px;
+    min-height: 32px;
     width: auto;
     padding: 0 12px;
     justify-content: center;
 
     svg,
     img {
-      height: 50%;
       width: auto;
     }
   }

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -501,7 +501,6 @@
 
   // 侧边栏按钮 非顶部工具栏
   .cherry-toolbar-button {
-    width: 30px;
     height: 30px;
     padding: 0 6px;
     color: var(--toolbar-btn-color);

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -501,6 +501,7 @@
 
   // 侧边栏按钮 非顶部工具栏
   .cherry-toolbar-button {
+    width: 30px;
     height: 30px;
     padding: 0 6px;
     color: var(--toolbar-btn-color);

--- a/packages/cherry-markdown/src/toolbars/BubbleFormula.js
+++ b/packages/cherry-markdown/src/toolbars/BubbleFormula.js
@@ -505,7 +505,7 @@ export default class BubbleFormula {
 
     // 是否显示 latexlive 外链
     const appendLatexLive = this.showLatexLive
-      ? `<div class="cherry-insert-formula-more"<a href="https://www.latexlive.com/" target="_blank">查看更多</a></div>`
+      ? `<div class="cherry-insert-formula-more"><a href="https://www.latexlive.com/" target="_blank">查看更多（LaTeXLive）</a></div>`
       : '';
 
     // 返回最终 HTML 字符串

--- a/packages/cherry-markdown/src/toolbars/BubbleFormula.js
+++ b/packages/cherry-markdown/src/toolbars/BubbleFormula.js
@@ -421,6 +421,11 @@ export default class BubbleFormula {
     // 获取一级菜单配置项
     const entries = Object.entries(this.formulaConfig || {});
 
+    // 是否显示 latexlive 外链
+    const appendLatexLive = this.showLatexLive
+      ? `<div class="cherry-insert-formula-more"><a href="https://www.latexlive.com/" target="_blank">查看更多 (LaTeXLive)</a></div>`
+      : '';
+
     // 左侧一级侧边栏 HTML
     const mainNavStr = entries
       .map(
@@ -430,7 +435,7 @@ export default class BubbleFormula {
           }" data-name="${menuKey}"><span>${title}</span></li>`,
       )
       .join('');
-    const mainNav = `<nav class="cherry-formula-nav"><ul class="cherry-formula-main-tabs">${mainNavStr}</ul></nav>`;
+    const mainNav = `<nav class="cherry-formula-nav"><ul class="cherry-formula-main-tabs">${mainNavStr}</ul>${appendLatexLive}</nav>`;
 
     // 右侧内容区
     const contentAreaStr = entries
@@ -475,7 +480,6 @@ export default class BubbleFormula {
                   groupHtml += `<div class="cherry-formula-grid-group"><div class="cherry-formula-grid-items">`;
                   inGroup = true;
                 }
-                // TODO：后续直接换成 SVG 文件，不要用直接放在上面的方式
                 const svgCode = formula.img || '';
                 groupHtml += `<div class="cherry-formula-item ${itemClass} ${
                   formula.formulaClass || ''
@@ -503,13 +507,8 @@ export default class BubbleFormula {
 
     const contentWrapper = `<div class="cherry-formula-content-wrapper">${contentAreaStr}</div>`;
 
-    // 是否显示 latexlive 外链
-    const appendLatexLive = this.showLatexLive
-      ? `<div class="cherry-insert-formula-more"><a href="https://www.latexlive.com/" target="_blank">查看更多（LaTeXLive）</a></div>`
-      : '';
-
     // 返回最终 HTML 字符串
-    return `${mainNav}${contentWrapper}${appendLatexLive}`;
+    return `${mainNav}${contentWrapper}`;
   }
 
   /**

--- a/packages/cherry-markdown/src/toolbars/BubbleFormula.js
+++ b/packages/cherry-markdown/src/toolbars/BubbleFormula.js
@@ -391,6 +391,181 @@ export default class BubbleFormula {
         },
       },
     },
+    font: {
+      title: '文本样式',
+      subCategory: {
+        color: {
+          title: '颜色',
+          formulas: [
+            {
+              name: '文本颜色',
+              img: '',
+              latex: '',
+            },
+            {
+              name: '蓝色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#1976D2" font-family="Arial, sans-serif">蓝色 Blue</text></svg>`,
+              latex: '{\\color{Blue} } ',
+            },
+            {
+              name: '棕色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#8D6E63" font-family="Arial, sans-serif">棕色 Brown</text></svg>`,
+              latex: '{\\color{Brown} } ',
+            },
+            {
+              name: '灰色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#757575" font-family="Arial, sans-serif">灰色 Gray</text></svg>`,
+              latex: '{\\color{Gray} } ',
+            },
+            {
+              name: '绿色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#388E3C" font-family="Arial, sans-serif">绿色 Green</text></svg>`,
+              latex: '{\\color{Green} } ',
+            },
+            {
+              name: '橙色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#FF9800" font-family="Arial, sans-serif">橙色 Orange</text></svg>`,
+              latex: '{\\color{Orange} } ',
+            },
+            {
+              name: '桃色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#FFAB91" font-family="Arial, sans-serif">桃色 Peach</text></svg>`,
+              latex: '{\\color{Peach} } ',
+            },
+            {
+              name: '紫色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#7B1FA2" font-family="Arial, sans-serif">紫色 Purple</text></svg>`,
+              latex: '{\\color{Purple} } ',
+            },
+            {
+              name: '红色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#D32F2F" font-family="Arial, sans-serif">红色 Red</text></svg>`,
+              latex: '{\\color{Red} } ',
+            },
+            {
+              name: '棕褐色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#D2B48C" font-family="Arial, sans-serif">棕褐色 Tan</text></svg>`,
+              latex: '{\\color{Tan} } ',
+            },
+            {
+              name: '紫罗兰色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#8E24AA" font-family="Arial, sans-serif">紫罗兰 Violet</text></svg>`,
+              latex: '{\\color{Violet} } ',
+            },
+            {
+              name: '黄色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#FBC02D" font-family="Arial, sans-serif">黄色 Yellow</text></svg>`,
+              latex: '{\\color{Yellow} } ',
+            },
+            {
+              name: '黑色文字',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#000000" font-family="Arial, sans-serif">黑色 Black</text></svg>`,
+              latex: '{\\color[RGB]{0,0,0} } ',
+            },
+            {
+              name: '背景颜色',
+              img: '',
+              latex: '',
+            },
+            {
+              name: '蓝色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#E3F2FD"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#1976D2" font-family="Arial, sans-serif">蓝色 Blue</text></svg>`,
+              latex: '{\\colorbox{Blue}{ } } ',
+            },
+            {
+              name: '棕色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#EFEBE9"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#8D6E63" font-family="Arial, sans-serif">棕色 Brown</text></svg>`,
+              latex: '{\\colorbox{Brown}{ } } ',
+            },
+            {
+              name: '灰色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#F5F5F5"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#757575" font-family="Arial, sans-serif">灰色 Gray</text></svg>`,
+              latex: '{\\colorbox{Gray}{ } } ',
+            },
+            {
+              name: '绿色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#E8F5E8"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#388E3C" font-family="Arial, sans-serif">绿色 Green</text></svg>`,
+              latex: '{\\colorbox{Green}{ } } ',
+            },
+            {
+              name: '橙色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#FFF3E0"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#FF9800" font-family="Arial, sans-serif">橙色 Orange</text></svg>`,
+              latex: '{\\colorbox{Orange}{ } } ',
+            },
+            {
+              name: '桃色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#FFF8F5"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#FFAB91" font-family="Arial, sans-serif">桃色 Peach</text></svg>`,
+              latex: '{\\colorbox{Peach}{ } } ',
+            },
+            {
+              name: '紫色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#F3E5F5"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#7B1FA2" font-family="Arial, sans-serif">紫色 Purple</text></svg>`,
+              latex: '{\\colorbox{Purple}{ } } ',
+            },
+            {
+              name: '红色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#FFEBEE"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#D32F2F" font-family="Arial, sans-serif">红色 Red</text></svg>`,
+              latex: '{\\colorbox{Red}{ } } ',
+            },
+            {
+              name: '黄色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#FFFDE7"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#F57F17" font-family="Arial, sans-serif">黄色 Yellow</text></svg>`,
+              latex: '{\\colorbox{Yellow}{ } } ',
+            },
+            {
+              name: '白色背景',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="20" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/><text x="40" y="15" text-anchor="middle" font-size="13" fill="#424242" font-family="Arial, sans-serif">白色 White</text></svg>`,
+              latex: '{\\colorbox{White}{ } } ',
+            },
+          ],
+        },
+        fontSize: {
+          title: '字号',
+          formulas: [
+            {
+              name: '极小字体',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="8" fill="#333" font-family="Arial, sans-serif">tiny 极小</text></svg>`,
+              latex: '{\\tiny } ',
+            },
+            {
+              name: '脚本字体',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="10" fill="#333" font-family="Arial, sans-serif">script 脚本</text></svg>`,
+              latex: '{\\scriptsize } ',
+            },
+            {
+              name: '正常字体',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="13" fill="#333" font-family="Arial, sans-serif">normal 正常</text></svg>`,
+              latex: '{\\normalsize } ',
+            },
+            {
+              name: '大字体',
+              img: `<svg width="80" height="20" viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg"><text x="40" y="15" text-anchor="middle" font-size="15" fill="#333" font-family="Arial, sans-serif">large 大</text></svg>`,
+              latex: '{\\large } ',
+            },
+            {
+              name: '较大字体',
+              img: `<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg"><text x="60" y="26" text-anchor="middle" font-size="17" fill="#333" font-family="Arial, sans-serif">Large 较大</text></svg>`,
+              latex: '{\\Large } ',
+            },
+            {
+              name: '很大字体',
+              img: `<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg"><text x="60" y="27" text-anchor="middle" font-size="19" fill="#333" font-family="Arial, sans-serif">LARGE 很大</text></svg>`,
+              latex: '{\\LARGE } ',
+            },
+            {
+              name: '巨大字体',
+              img: `<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg"><text x="60" y="28" text-anchor="middle" font-size="21" fill="#333" font-family="Arial, sans-serif">huge 巨大</text></svg>`,
+              latex: '{\\huge } ',
+            },
+            {
+              name: '超大字体',
+              img: `<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg"><text x="60" y="29" text-anchor="middle" font-size="23" fill="#333" font-family="Arial, sans-serif">Huge 超大</text></svg>`,
+              latex: '{\\Huge } ',
+            },
+          ],
+        },
+      },
+    },
   };
 
   /**

--- a/packages/cherry-markdown/src/toolbars/hooks/Formula.js
+++ b/packages/cherry-markdown/src/toolbars/hooks/Formula.js
@@ -46,8 +46,17 @@ export default class Formula extends MenuBase {
   onClick(selection, shortKey = '') {
     if (this.subBubbleFormulaMenu.isHide() || !this.hasCacheOnce()) {
       const pos = this.dom.getBoundingClientRect();
-      this.subBubbleFormulaMenu.dom.style.left = `${pos.left + pos.width}px`;
-      this.subBubbleFormulaMenu.dom.style.top = `${pos.top + pos.height}px`;
+      const menuDom = this.subBubbleFormulaMenu.dom;
+      // 计算弹窗宽度，防止超出右侧
+      const menuWidth = menuDom.offsetWidth || 680;
+      const pageWidth = document.documentElement.clientWidth;
+      let left = pos.left + pos.width;
+      if (left + menuWidth > pageWidth) {
+        left = pageWidth - menuWidth - 8;
+        if (left < 0) left = 0;
+      }
+      menuDom.style.left = `${left}px`;
+      menuDom.style.top = `${pos.top + pos.height}px`;
       this.subBubbleFormulaMenu.show((latex) => {
         const before = /\n/.test(latex)
           ? `${/\n$/.test(selection) ? selection : `${selection}\n`}$$`


### PR DESCRIPTION
- refactor: 对公式面板的界面的重构
- feat: 增加“文本样式”页
- fix: 修复公式菜单位置计算，防止超出右侧边界

<img width="2008" height="5052" alt="PixPin_2025-08-02_14-51-28" src="https://github.com/user-attachments/assets/38f7fd8e-b4ff-47fd-9d43-899587d9dc2f" />