### PR TITLE
feat: #1231 添加导出 Word 文档的功能

### DIFF
--- a/.changeset/feat-word-export.md
+++ b/.changeset/feat-word-export.md
@@ -1,0 +1,7 @@
+---
+'cherry-markdown': patch
+---
+
+feat: 添加导出 Word 文档的功能
+
+feat: 在 window.print() 不可用时，关闭导出 PDF 的功能

--- a/packages/cherry-markdown/src/Previewer.js
+++ b/packages/cherry-markdown/src/Previewer.js
@@ -21,7 +21,7 @@ import { getBlockTopAndHeightWithMargin } from './utils/dom';
 import Logger from './Logger';
 // import locale from './utils/locale';
 import { addEvent, removeEvent } from './utils/event';
-import { exportPDF, exportScreenShot, exportMarkdownFile, exportHTMLFile } from './utils/export';
+import { exportPDF, exportScreenShot, exportMarkdownFile, exportHTMLFile, exportWordFile } from './utils/export';
 import PreviewerBubble from './toolbars/PreviewerBubble';
 import LazyLoadImg from '@/utils/lazyLoadImg';
 
@@ -1141,8 +1141,8 @@ export default class Previewer {
   /**
    * 导出预览区域内容
    * @public
-   * @param {'pdf' | 'img' | 'screenShot' | 'markdown' | 'html'} [type='pdf']
-   * 'pdf'：导出成pdf文件; 'img' | screenShot：导出成png图片; 'markdown'：导出成markdown文件; 'html'：导出成html文件;
+   * @param {'pdf' | 'img' | 'screenShot' | 'markdown' | 'html' | 'word'} [type='pdf']
+   * 'pdf'：导出成pdf文件; 'img' | screenShot：导出成png图片; 'markdown'：导出成markdown文件; 'html'：导出成html文件; 'word'：导出到Word（复制到剪贴板）;
    * @param {string} [fileName] 导出文件名
    */
   export(type = 'pdf', fileName = '') {
@@ -1155,6 +1155,8 @@ export default class Previewer {
       exportMarkdownFile(this.$cherry.getMarkdown(), name);
     } else if (type === 'html') {
       exportHTMLFile(this.getValue(), name);
+    } else if (type === 'word') {
+      exportWordFile(this.getValue(), name);
     }
   }
 }

--- a/packages/cherry-markdown/src/locales/en_US.js
+++ b/packages/cherry-markdown/src/locales/en_US.js
@@ -80,6 +80,7 @@ export default {
   exportScreenshot: 'Screenshot',
   exportMarkdownFile: 'Export Markdown File',
   exportHTMLFile: 'Export preview HTML File',
+  exportWordFile: 'Export to Word',
   heading1: 'H1 Heading',
   heading2: 'H2 Heading',
   heading3: 'H3 Heading',

--- a/packages/cherry-markdown/src/locales/ru_RU.js
+++ b/packages/cherry-markdown/src/locales/ru_RU.js
@@ -80,6 +80,7 @@ export default {
   exportScreenshot: 'Скриншот',
   exportMarkdownFile: 'Экспорт файла Markdown',
   exportHTMLFile: 'Экспорт предварительного просмотра HTML-файла',
+  exportWordFile: 'Экспорт в Word',
   panel: 'Панель',
   detail: 'Аккордеон',
   heading1: 'H1 Заголовок',

--- a/packages/cherry-markdown/src/locales/zh_CN.js
+++ b/packages/cherry-markdown/src/locales/zh_CN.js
@@ -81,6 +81,7 @@ export default {
   exportScreenshot: '导出长图', // 导出长图
   exportMarkdownFile: '导出markdown', // 导出markdown文件
   exportHTMLFile: '导出html', // 导出预览区html文件
+  exportWordFile: '导出word', // 导出Word文件
   theme: '主题', // 导出长图
   panel: '面板', // 导出长图
   detail: '手风琴', // 手风琴

--- a/packages/cherry-markdown/src/toolbars/hooks/Export.js
+++ b/packages/cherry-markdown/src/toolbars/hooks/Export.js
@@ -33,6 +33,7 @@ export default class Export extends MenuBase {
       { noIcon: true, name: 'exportScreenshot', onclick: this.bindSubClick.bind(this, 'screenShot') },
       { noIcon: true, name: 'exportMarkdownFile', onclick: this.bindSubClick.bind(this, 'markdown') },
       { noIcon: true, name: 'exportHTMLFile', onclick: this.bindSubClick.bind(this, 'html') },
+      { noIcon: true, name: 'exportWordFile', onclick: this.bindSubClick.bind(this, 'word') },
     );
   }
 

--- a/packages/cherry-markdown/src/utils/export.js
+++ b/packages/cherry-markdown/src/utils/export.js
@@ -152,3 +152,121 @@ export function exportHTMLFile(HTMLText, fileName) {
   aLink.click();
   document.body.removeChild(aLink);
 }
+
+/**
+ * 导出到 Word (通过复制 HTML 到剪贴板)
+ * @param {String} HTMLText HTML文本
+ * @param {String} fileName 文件名
+ */
+export async function exportWordFile(HTMLText, fileName) {
+  // 创建完整的HTML文档结构，包含样式，确保在Word中有更好的显示效果
+  const fullHTML = `
+  <!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset="utf-8">
+    <title>${fileName}</title>
+    <style>
+        body { 
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: none;
+            margin: 0;
+            padding: 20px;
+        }
+        img { max-width: 100%; height: auto; }
+        table { border-collapse: collapse; width: 100%; }
+        table, th, td { border: 1px solid #ddd; padding: 8px; }
+        th { background-color: #f2f2f2; }
+        code { 
+            background-color: #f4f4f4; 
+            padding: 2px 4px; 
+            border-radius: 3px; 
+            font-family: 'Monaco', 'Consolas', monospace;
+        }
+        pre { 
+            background-color: #f4f4f4; 
+            padding: 10px; 
+            border-radius: 5px; 
+            overflow-x: auto;
+        }
+        blockquote {
+            border-left: 4px solid #ddd;
+            margin: 0;
+            padding-left: 16px;
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+${HTMLText}
+</body>
+</html>`;
+
+  if (navigator.clipboard && navigator.clipboard.write) {
+    const clipboardItem = new ClipboardItem({
+      'text/html': new Blob([fullHTML], { type: 'text/html' }),
+    });
+    await navigator.clipboard.write([clipboardItem]);
+    showExportWordTip(fileName);
+  } else {
+    throw new Error('浏览器未授权粘贴板或不支持剪贴板写入');
+  }
+}
+
+/**
+ * 显示导出 Word 的操作提示
+ * @param {String} fileName 文件名
+ */
+function showExportWordTip(fileName) {
+  const tipHTML = `
+    <div style="
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: var(--base-editor-bg);
+      border: 1px solid var(--base-border-color);
+      border-radius: var(--radius-xl);
+      padding: var(--spacing-lg);
+      box-shadow: var(--shadow-md);
+      z-index: 99999;
+      max-width: 400px;
+      text-align: center;
+      font-family: var(--font-family-base, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+    ">
+      <h3 style="margin: 0 0 var(--spacing-md) 0; color: var(--base-font-color);">内容已复制到剪贴板</h3>
+      <p style="margin: 0 0 var(--spacing-md) 0; color: var(--base-sub-font-color); line-height: var(--line-height-relaxed);">
+        请打开 Microsoft Word，然后按 <strong>Ctrl+V</strong>（Windows）或 <strong>Cmd+V</strong>（Mac）粘贴内容。
+      </p>
+      <p style="margin: 0 0 var(--spacing-lg) 0; color: var(--base-sub-font-color); font-size: var(--font-size-sm);">
+        公式、mermaid 图表等可能无法正确显示
+      </p>
+      <button onclick="this.parentElement.parentElement.remove()" style="
+        background: var(--secondary-color);
+        color: var(--primary-color);
+        border: none;
+        padding: var(--spacing-sm) var(--spacing-md);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+        font-size: var(--font-size-sm);
+        height: var(--height-button);
+      ">了解</button>
+    </div>
+    <div style="
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.3);
+      z-index: 99998;
+    " onclick="this.parentElement.remove();"></div>
+  `;
+
+  const tipElement = document.createElement('div');
+  tipElement.className = 'cherry';
+  tipElement.innerHTML = tipHTML;
+  document.body.appendChild(tipElement);
+}


### PR DESCRIPTION
Resolve #1231 

2025 腾讯犀牛鸟

---

feat: 添加导出 Word 文档的功能
feat: 在 `window.print()` 不可用时，关闭导出 PDF 的功能

---

目前是采用将 HTML 写入用户粘贴板，引导用户放入 Word 中，借助 Word 自身来实现从 HTML 到 Word 格式的转换；主要在 公式、mermaid 导出存在问题