### PR TITLE
feat: #1062 添加输入联想功能配置，支持自定义候选项

### DIFF
--- a/.changeset/feat-suggester-enhance.md
+++ b/.changeset/feat-suggester-enhance.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': minor
+---
+
+feat: 支持输入联想功能配置，支持自定义候选项

--- a/packages/cherry-markdown/src/Cherry.config.js
+++ b/packages/cherry-markdown/src/Cherry.config.js
@@ -294,6 +294,149 @@ const defaultConfig = {
          **/
         customBtns: [],
       },
+      // 输入联想（/、、、` 等触发）的配置
+      suggester: {
+        /**
+         * 方式1：完全覆盖默认的系统候选项
+         * 用法：替换所有默认的 /、、、` 等触发的候选项
+         */
+        // systemSuggestList: [
+        //   {
+        //     icon: 'h1',
+        //     label: 'heading1',
+        //     keyword: 'head1',
+        //     value: '# ',
+        //   },
+        //   {
+        //     icon: 'h2',
+        //     label: 'heading2',
+        //     keyword: 'head2',
+        //     value: '## ',
+        //   },
+        //   {
+        //     icon: 'table',
+        //     label: 'table',
+        //     keyword: 'table',
+        //     value: '| 列1 | 列2 | 列3 |\n| --- | --- | --- |\n| 内容1 | 内容2 | 内容3 |\n',
+        //   },
+        //   {
+        //     icon: 'code',
+        //     label: 'code',
+        //     keyword: 'code',
+        //     value: '```javascript\n\n```\n',
+        //     goTop: 2, // 插入后光标上移2行
+        //   },
+        //   {
+        //     icon: 'link',
+        //     label: 'link',
+        //     keyword: 'link',
+        //     value: '[链接文本](https://example.com)',
+        //     selection: { from: '[链接文本](https://example.com)'.length, to: '](https://example.com)'.length }, // 选中"链接文本"
+        //   },
+        // ],
+        /**
+         * 方式2：在默认系统候选项基础上追加
+         * 用法：保留所有默认项，额外增加自定义项
+         */
+        // extendSystemSuggestList: [
+        //   {
+        //     icon: 'pen',
+        //     label: 'template',
+        //     keyword: 'template temp',
+        //     value: '## 标题\n\n### 子标题\n\n内容...\n\n---\n\n**总结：**\n\n',
+        //     goTop: 6, // 插入后光标上移到内容位置
+        //   },
+        //   {
+        //     icon: 'insertFlow',
+        //     label: 'meeting',
+        //     keyword: 'meeting',
+        //     value: '## 会议记录\n\n**时间：** \n**参与人：** \n**议题：** \n\n### 讨论内容\n\n### 行动项\n- [ ] \n\n',
+        //   },
+        // ],
+        /**
+         * 方式3：自定义触发符联想（如 @用户、#话题、$变量等）
+         * 用法：输入"空格+触发符+文本"时显示动态候选项
+         * 触发示例：输入 " @张" 会调用 suggestList("张", callback)
+         */
+        // suggester: [
+        //   // @用户提及
+        //   {
+        //     keyword: '@',
+        //     suggestList(word, callback) {
+        //       const searchTerm = word.replace(/^@/, '');
+        //       // 模拟用户数据（实际项目中可以调用API）
+        //       const users = [
+        //         { id: 1, name: '张三', avatar: 'avatar1.jpg' },
+        //         { id: 2, name: '李四', avatar: 'avatar2.jpg' },
+        //         { id: 3, name: '王五', avatar: 'avatar3.jpg' },
+        //         { id: 4, name: '赵六', avatar: 'avatar4.jpg' },
+        //       ];
+        //       // 如果没有搜索词，显示所有用户
+        //       const filtered = searchTerm === '' ? users : users.filter(user =>
+        //         user.name.toLowerCase().includes(searchTerm.toLowerCase())
+        //       );
+        //       // 如果没有匹配项，关闭联想
+        //       if (filtered.length === 0) {
+        //         callback(false);
+        //         return;
+        //       }
+        //       // 返回候选项
+        //       const suggestions = filtered.map(user => ({
+        //         label: user.name,
+        //         value: `@${user.name} `, // 插入的内容
+        //         icon: 'user', // 图标
+        //       }));
+        //       callback(suggestions);
+        //       // 异步示例：
+        //       // fetch(`/api/users?q=${encodeURIComponent(word)}`)
+        //       //   .then(response => response.json())
+        //       //   .then(users => {
+        //       //     callback(users.map(user => ({
+        //       //       label: user.name,
+        //       //       value: `@${user.name} `,
+        //       //     })));
+        //       //   })
+        //       //   .catch(() => callback(false));
+        //     },
+        //     // 可选：自定义候选面板的渲染
+        //     suggestListRender(list) {
+        //       // 返回自定义HTML或DOM元素，留空使用默认样式
+        //       return '';
+        //     },
+        //     // 可选：自定义行内回显样式
+        //     echo(value) {
+        //       // 返回空串使用默认高亮，返回false关闭回显
+        //       return '';
+        //     },
+        //   },
+        //   // $变量引用
+        //   {
+        //     keyword: '$',
+        //     suggestList(word, callback) {
+        //       const searchTerm = word.replace(/^\$/, '');
+        //       const variables = [
+        //         { name: 'API_URL', value: 'https://api.example.com', desc: 'API基础地址' },
+        //         { name: 'VERSION', value: '1.0.0', desc: '当前版本号' },
+        //         { name: 'DEBUG', value: 'true', desc: '调试模式' },
+        //       ];
+        //       // 如果没有搜索词，显示所有变量
+        //       const filtered = searchTerm === '' ? variables : variables.filter(v =>
+        //         v.name.toLowerCase().includes(searchTerm.toLowerCase())
+        //       );
+        //       if (filtered.length === 0) {
+        //         callback(false);
+        //         return;
+        //       }
+        //       const suggestions = filtered.map(variable => ({
+        //         label: `${variable.name} - ${variable.desc}`,
+        //         value: `\`${variable.value}\``,
+        //         icon: 'code',
+        //       }));
+        //       callback(suggestions);
+        //     },
+        //   },
+        // ],
+      },
       emoji: {
         useUnicode: true, // 是否使用unicode进行渲染
       },

--- a/packages/cherry-markdown/src/core/hooks/SuggestList.js
+++ b/packages/cherry-markdown/src/core/hooks/SuggestList.js
@@ -312,8 +312,25 @@ const CodeLangSuggestList = (() => {
  */
 const OtherSuggestList = HalfWidthSuggestList.concat(MoreSuggestList).concat(CodeLangSuggestList);
 
-export function allSuggestList(keyword, locales) {
-  const systemSuggestList = SystemSuggestList.map((item) => ({
+export function allSuggestList(keyword, locales, suggesterConfig) {
+  // 支持通过 Cherry.config.js -> engine.syntax.suggester 注入系统候选项
+  // 优先级：config.systemSuggestList 覆盖默认 → 默认 + config.extendSystemSuggestList 追加
+  let effectiveSystemList = SystemSuggestList;
+  if (
+    suggesterConfig &&
+    Array.isArray(suggesterConfig.systemSuggestList) &&
+    suggesterConfig.systemSuggestList.length > 0
+  ) {
+    effectiveSystemList = suggesterConfig.systemSuggestList;
+  } else if (
+    suggesterConfig &&
+    Array.isArray(suggesterConfig.extendSystemSuggestList) &&
+    suggesterConfig.extendSystemSuggestList.length > 0
+  ) {
+    effectiveSystemList = SystemSuggestList.concat(suggesterConfig.extendSystemSuggestList);
+  }
+
+  const systemSuggestList = effectiveSystemList.map((item) => ({
     ...item,
     label: locales[item.label] || item.label,
   }));

--- a/packages/cherry-markdown/src/core/hooks/Suggester.js
+++ b/packages/cherry-markdown/src/core/hooks/Suggester.js
@@ -113,7 +113,7 @@ export default class Suggester extends SyntaxBase {
         suggestList(_word, callback) {
           // 将word全转成小写
           const word = _word.toLowerCase();
-          const systemSuggestList = allSuggestList(suggesterKeyword, that.$cherry.locale);
+          const systemSuggestList = allSuggestList(suggesterKeyword, that.$cherry.locale, that.config);
           // 加个空格就直接退出联想
           if (/^\s$/.test(word)) {
             callback(false);

--- a/packages/cherry-markdown/types/cherry.d.ts
+++ b/packages/cherry-markdown/types/cherry.d.ts
@@ -501,10 +501,55 @@ export interface CherryEngineOptions {
                 render?: (refNum: number, refTitle: string, content: string) => string; // 自定义渲染卡片内容
               };
         };
+    /**
+     * 输入联想（/、全角符号、反引号等触发）的配置
+     */
+    suggester?:
+      | false
+      | {
+          /** 完全覆盖默认的系统候选项 */
+          systemSuggestList?: SuggesterItem[];
+          /** 在默认系统候选项基础上追加 */
+          extendSystemSuggestList?: SuggesterItem[];
+          /** 自定义联想（如 @ 等）列表 */
+          suggester?: Array<{
+            /** 获取候选列表 */
+            suggestList: (
+              word: string,
+              callback: (list: Array<string | SuggesterCallbackItem> | false) => void,
+            ) => void;
+            /** 唤醒关键字，默认 '@' */
+            keyword?: string;
+            /** 自定义候选面板渲染 */
+            suggestListRender?: (valueArray: Array<string | SuggesterCallbackItem>) => string | Element | Element[];
+            /** 自定义回显，返回空串可使用默认回显；返回 false 关闭回显 */
+            echo?: ((value: string) => string) | false;
+          }>;
+        };
   };
   /** 自定义语法 */
   customSyntax?: Record<string, CustomSyntaxRegConfig['syntaxClass'] | CustomSyntaxRegConfig>;
 }
+
+export type SuggesterItem = {
+  icon?: string;
+  label: string;
+  keyword: string;
+  value: string | (() => string);
+  goLeft?: number;
+  goTop?: number;
+  selection?: { from: number; to: number };
+  exactMatch?: boolean;
+};
+
+export type SuggesterCallbackItem = {
+  icon?: string;
+  label: string;
+  value: string | (() => string);
+  goLeft?: number;
+  goTop?: number;
+  selection?: { from: number; to: number };
+};
 
 export type EditorMode =
   /** 仅编辑 */


### PR DESCRIPTION
resolves #1062

---

suggest 联想菜单目前支持自定义配置

一个计划了三种模式：

1. 完全覆盖默认的系统候选项
2. 在默认系统候选项基础上追加
3. 自定义触发符联想（如 @用户、$变量等），能和系统候选一起用