### PR TITLE
fix: #1367 调整建议面板位置以避免超出边界

### DIFF
--- a/.changeset/adjust-suggester-position.md
+++ b/.changeset/adjust-suggester-position.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 调整建议面板位置以避免超出边界

--- a/packages/cherry-markdown/src/core/hooks/Suggester.js
+++ b/packages/cherry-markdown/src/core/hooks/Suggester.js
@@ -244,6 +244,7 @@ class SuggesterPanel {
     this.cursorMove = true;
     this.suggesterConfig = {};
     this.$cherry = cherry;
+    this.panelPosition = 'below'; // 面板相对光标的显示位置（上方或下方）：'below' | 'above'
   }
 
   /**
@@ -375,6 +376,7 @@ class SuggesterPanel {
       this.$cherry.wrapperDom.appendChild(this.createDom(this.panelWrap));
       this.$suggesterPanel = this.$cherry.wrapperDom.querySelector('.cherry-suggester-panel');
     }
+
     this.updatePanel(items);
     this.$suggesterPanel.style.left = `${left}px`;
     this.$suggesterPanel.style.top = `${top}px`;
@@ -458,7 +460,10 @@ class SuggesterPanel {
     return frag;
   }
 
-  // 面板重定位
+  /**
+   * 面板重定位（滚动时调用，不进行边界判定）
+   * @param {CodeMirror} codemirror
+   */
   relocatePanel(codemirror) {
     // 找到光标位置来确定候选框位置
     let $cursor = this.$cherry.wrapperDom.querySelector('.CodeMirror-cursors .CodeMirror-cursor');
@@ -469,10 +474,25 @@ class SuggesterPanel {
     if (!$cursor) {
       return false;
     }
+
     const editorDomRect = this.$cherry.wrapperDom.getBoundingClientRect();
-    const rect = $cursor.getBoundingClientRect();
-    const top = rect.top + rect.height + 5 - editorDomRect.top;
-    const left = rect.left - editorDomRect.left;
+    const cursorRect = $cursor.getBoundingClientRect();
+
+    const left = cursorRect.left - editorDomRect.left;
+    const cursorTop = cursorRect.top - editorDomRect.top;
+    const cursorHeight = cursorRect.height;
+
+    let top;
+
+    // 根据之前记录的位置关系计算新位置
+    if (this.panelPosition === 'below') {
+      top = cursorTop + cursorHeight + 5;
+    } else {
+      // 需要获取面板当前高度
+      const panelHeight = this.$suggesterPanel ? this.$suggesterPanel.offsetHeight : 380;
+      top = cursorTop - panelHeight - 5;
+    }
+
     this.showSuggesterPanel({ left, top, items: this.optionList });
   }
 
@@ -497,7 +517,77 @@ class SuggesterPanel {
     this.cursorFrom = from;
     this.keyword = keyword;
     this.searchCache = true;
-    this.relocatePanel(codemirror);
+
+    // 在下一帧进行首次定位和边界判定
+    requestAnimationFrame(() => {
+      this.relocatePanelWithBoundaryCheck();
+    });
+  }
+
+  /**
+   * 首次显示面板时进行边界判定（在下一帧执行）
+   */
+  relocatePanelWithBoundaryCheck() {
+    // 先创建并显示面板以获取实际高度（默认是 380px）
+    this.tryCreatePanel();
+    this.updatePanel(this.optionList);
+
+    this.$suggesterPanel.style.visibility = 'hidden';
+    this.$suggesterPanel.style.display = 'block';
+    this.$suggesterPanel.style.position = 'absolute';
+
+    const actualPanelHeight = this.$suggesterPanel.offsetHeight || 380;
+
+    let $cursor = this.$cherry.wrapperDom.querySelector('.CodeMirror-cursors .CodeMirror-cursor');
+    if (!$cursor) {
+      $cursor = this.$cherry.wrapperDom.querySelector('.CodeMirror-selected');
+    }
+    if (!$cursor) {
+      this.$suggesterPanel.style.display = 'none';
+      return false;
+    }
+
+    const editorDomRect = this.$cherry.wrapperDom.getBoundingClientRect();
+    const cursorRect = $cursor.getBoundingClientRect();
+
+    // 计算位置
+    const left = cursorRect.left - editorDomRect.left;
+    const cursorTop = cursorRect.top - editorDomRect.top;
+    const cursorHeight = cursorRect.height;
+    const cursorBottomInView = cursorTop + cursorHeight;
+
+    // 获取可用空间
+    const editorHeight = this.$cherry.wrapperDom.clientHeight;
+    const spaceBelow = editorHeight - cursorBottomInView;
+    const spaceAbove = cursorTop;
+
+    // 边界判定
+    let top;
+
+    if (spaceBelow >= actualPanelHeight + 10) {
+      // 下方空间足够
+      top = cursorBottomInView + 5;
+      this.panelPosition = 'below';
+    } else if (spaceAbove >= actualPanelHeight + 10) {
+      // 上方空间足够
+      top = cursorTop - actualPanelHeight - 5;
+      this.panelPosition = 'above';
+    } else {
+      // 两边都不够，选择空间较大的一边
+      if (spaceBelow > spaceAbove) {
+        top = cursorBottomInView + 5;
+        this.panelPosition = 'below';
+      } else {
+        top = Math.max(10, cursorTop - actualPanelHeight - 5);
+        this.panelPosition = 'above';
+      }
+    }
+
+    // 设置最终位置并显示
+    this.$suggesterPanel.style.left = `${left}px`;
+    this.$suggesterPanel.style.top = `${top}px`;
+    this.$suggesterPanel.style.visibility = 'visible';
+    this.$suggesterPanel.style.zIndex = '100';
   }
 
   // 关闭关联
@@ -510,6 +600,7 @@ class SuggesterPanel {
     this.searchCache = false;
     this.cursorMove = true;
     this.optionList = [];
+    this.panelPosition = 'below'; // 重置面板位置记录
   }
 
   /**


### PR DESCRIPTION
fix #1367 


目前的策略主要是拆开了 `relocatePanel()` 的职责，原本初次打开面板和页面滚动都是用这个来刷新位置的，现在在初次打开面板那边加上了边界的判断和位置的初步调整，打开面板的逻辑如下：

`用户输入 → startRelate() → requestAnimationFrame() → 获取真实高度 → 边界判定 → 定位 → 显示面板`