### PR TITLE
feat: 添加 codemirror 的 placeholder 配置支持

### DIFF
--- a/.changeset/feat-codemirror-placeholder.md
+++ b/.changeset/feat-codemirror-placeholder.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+feat: 添加 codemirror 的 placeholder 配置支持

--- a/examples/assets/scripts/index-demo.js
+++ b/examples/assets/scripts/index-demo.js
@@ -383,6 +383,9 @@ var basicConfig = {
     showFullWidthMark: true, // 是否高亮全角符号 ·|￥|、|：|“|”|【|】|（|）|《|》
     showSuggestList: true, // 是否显示联想框
     maxUrlLength: 200, // url最大长度，超过则自动截断
+    codemirror: {
+      placeholder: '输入文本或「/」开始编辑'
+    }
   },
   // cherry初始化后是否检查 location.hash 尝试滚动到对应位置
   autoScrollByHashAfterInit: true,

--- a/packages/cherry-markdown/src/Cherry.config.js
+++ b/packages/cherry-markdown/src/Cherry.config.js
@@ -450,6 +450,7 @@ const defaultConfig = {
     codemirror: {
       // 是否自动focus 默认为true
       autofocus: true,
+      placeholder: '输入文本或「/」开始编辑',
     },
     writingStyle: 'normal', // 书写风格，normal 普通 | typewriter 打字机 | focus 专注，默认normal
     keepDocumentScrollAfterInit: false, // 在初始化后是否保持网页的滚动，true：保持滚动；false：网页自动滚动到cherry初始化的位置

--- a/packages/cherry-markdown/src/Cherry.config.js
+++ b/packages/cherry-markdown/src/Cherry.config.js
@@ -450,7 +450,8 @@ const defaultConfig = {
     codemirror: {
       // 是否自动focus 默认为true
       autofocus: true,
-      placeholder: '输入文本或「/」开始编辑',
+      // 在无内容时显示的占位符
+      placeholder: '',
     },
     writingStyle: 'normal', // 书写风格，normal 普通 | typewriter 打字机 | focus 专注，默认normal
     keepDocumentScrollAfterInit: false, // 在初始化后是否保持网页的滚动，true：保持滚动；false：网页自动滚动到cherry初始化的位置


### PR DESCRIPTION
Resolve #1131 

---

原有的 placeholder 会和浮动工具栏重合，我这边对浮动工具栏进行了一些适配

<img width="717" height="371" alt="image" src="https://github.com/user-attachments/assets/555f48cf-c107-487b-9437-c5e04f6a35c9" />

当然，也可考虑在有 placeholder 的时候，首行不显示浮动工具栏