### PR TITLE
feat: 添加行内代码颜色指示

### DIFF
--- a/.changeset/feat-inline-code-color.md
+++ b/.changeset/feat-inline-code-color.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+feat: 添加行内代码颜色指示

--- a/packages/cherry-markdown/src/Cherry.config.js
+++ b/packages/cherry-markdown/src/Cherry.config.js
@@ -261,6 +261,7 @@ const defaultConfig = {
          * @deprecated 不再支持theme的配置，统一在`themeSettings.inlineCodeTheme`中配置
          */
         // theme: 'red',
+        showColor: true, // 是否在行内代码为颜色值时展示颜色指示
       },
       codeBlock: {
         // theme: 'dark', //  @deprecated 不再支持theme的配置，统一在`themeSettings.codeBlockTheme`中配置

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -1037,6 +1037,19 @@
   }
 }
 
+/* 行内代码颜色小圆点样式 */
+.ch-inline-color {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.7em;
+  height: 0.7em;
+  border-radius: 100%;
+  border: var(--primary-color) solid 1px;
+  margin-left: 0.2em;
+  box-sizing: border-box;
+}
+
 .float-previewer-wrap {
   position: fixed;
   right: 0;


### PR DESCRIPTION
<img width="3032" height="788" alt="CleanShot 2025-08-22 at 16 57 36@2x" src="https://github.com/user-attachments/assets/346ba4b0-05cc-4a07-8228-dc572a26f4d7" />

主要参照 Github 自身对颜色的支持，我这边也支持如下

<img width="1100" height="392" alt="PixPin_2025-08-22_16-59-17" src="https://github.com/user-attachments/assets/a265377f-7e84-4d9c-bc0a-ef5f5da5ee50" />
