### PR TITLE
fix: 修复配图表格在脚注显示异常的问题

### DIFF
--- a/.changeset/major-lands-push.md
+++ b/.changeset/major-lands-push.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 修复配图表格在脚注显示异常的问题

--- a/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js
+++ b/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js
@@ -583,17 +583,7 @@ export default class EChartsTableEngine {
     // Logger.log('Chart options:', chartOption);
 
     // 创建一个包含所有必要信息的HTML结构
-    const htmlContent = `
-      <div class="cherry-echarts-wrapper" 
-           style="width: ${this.options.width}px; height: ${
-             this.options.height
-           }px; min-height: 300px; display: block; position: relative; border: 1px solid var(--md-table-border);" 
-           id="${chartId}"
-           data-chart-type="${type}"
-           data-table-data="${tableDataStr.replace(/"/g, '&quot;')}"
-           data-chart-options="${chartOptionsStr.replace(/"/g, '&quot;')}">
-      </div>
-    `;
+    const htmlContent = `<div class="cherry-echarts-wrapper" style="width: ${this.options.width}px; height: ${this.options.height}px; min-height: 300px; display: block; position: relative; border: 1px solid var(--md-table-border);" id="${chartId}" data-chart-type="${type}" data-table-data="${tableDataStr.replace(/"/g, '&quot;')}" data-chart-options="${chartOptionsStr.replace(/"/g, '&quot;')}"></div>`;
 
     // 延迟到下一轮事件循环再执行；只重试一次
     setTimeout(() => {

--- a/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js
+++ b/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js
@@ -582,8 +582,29 @@ export default class EChartsTableEngine {
     const chartOption = this.$generateChartOptions(type, tableObject, options);
     // Logger.log('Chart options:', chartOption);
 
+    // HTML样式配置
+    const styleConfig = {
+      width: `${this.options.width}px`,
+      height: `${this.options.height}px`,
+      'min-height': '300px',
+      display: 'block',
+      position: 'relative',
+      border: '1px solid var(--md-table-border)',
+    };
+    const styleStr = Object.entries(styleConfig)
+      .map(([key, value]) => `${key}: ${value};`)
+      .join(' ');
+
     // 创建一个包含所有必要信息的HTML结构
-    const htmlContent = `<div class="cherry-echarts-wrapper" style="width: ${this.options.width}px; height: ${this.options.height}px; min-height: 300px; display: block; position: relative; border: 1px solid var(--md-table-border);" id="${chartId}" data-chart-type="${type}" data-table-data="${tableDataStr.replace(/"/g, '&quot;')}" data-chart-options="${chartOptionsStr.replace(/"/g, '&quot;')}"></div>`;
+    const htmlContent = [
+      `<div class="cherry-echarts-wrapper"`,
+      ` style="${styleStr}"`,
+      ` id="${chartId}"`,
+      ` data-chart-type="${type}"`,
+      ` data-table-data="${tableDataStr.replace(/"/g, '&quot;')}"`,
+      ` data-chart-options="${chartOptionsStr.replace(/"/g, '&quot;')}">`,
+      `</div>`,
+    ].join('');
 
     // 延迟到下一轮事件循环再执行；只重试一次
     setTimeout(() => {


### PR DESCRIPTION
由于[cherry-table-echarts-plugin.js](https://github.com/Tencent/cherry-markdown/blob/dev/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js#L586)中引入了多行的`htmlContent`，在脚注中，会将不同行属性之间的换行符转换为`<br/>`，导致本该渲染的图表以文字出现。

将`htmlContent`的内容修改为一行可以解决问题，但代码可读性降低。因此我增加`styleConfig`对象来配置样式，并将`htmlContent`改为数组的形式进行拼接，以维持可读性。

**修改前：**
<img width="1902" height="700" alt="image" src="https://github.com/user-attachments/assets/9a3deb00-d783-43f5-9e20-8839fea422a8" />

**修改后：**
<img width="1898" height="848" alt="image" src="https://github.com/user-attachments/assets/84a19944-230b-4d84-8c6e-9d4eb34375ac" />
