### PR TITLE
style: 增加沉稳主题，主要恢复了曾经默认主题的样式

### DIFF
--- a/packages/cherry-markdown/src/Cherry.config.js
+++ b/packages/cherry-markdown/src/Cherry.config.js
@@ -830,6 +830,7 @@ const defaultConfig = {
     themeList: [
       { className: 'default', label: '默认' }, // 曾用名：light 明亮
       { className: 'dark', label: '暗黑' },
+      { className: 'gray', label: '沉稳' },
       { className: 'abyss', label: '深海' },
       { className: 'green', label: '清新' },
       { className: 'red', label: '热情' },

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -870,16 +870,6 @@
       background-color: var(--toolbar-btn-hover-bg);
       border-color: #eee;
     }
-    animation: pulse 2s infinite alternate;
-  }
-
-  @keyframes pulse {
-    0% {
-      box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-    }
-    100% {
-      box-shadow: 0 0 15px var(--primary-color);
-    }
   }
 }
 
@@ -1634,5 +1624,6 @@
 @import './themes/abyss.scss';
 @import './themes/green.scss';
 @import './themes/red.scss';
+@import './themes/gray.scss';
 @import './themes/violet.scss';
 @import './themes/blue.scss';

--- a/packages/cherry-markdown/src/sass/markdown_pure.scss
+++ b/packages/cherry-markdown/src/sass/markdown_pure.scss
@@ -5,5 +5,6 @@
 @import './themes/abyss.scss';
 @import './themes/green.scss';
 @import './themes/red.scss';
+@import './themes/gray.scss';
 @import './themes/violet.scss';
 @import './themes/blue.scss';

--- a/packages/cherry-markdown/src/sass/themes/gray.scss
+++ b/packages/cherry-markdown/src/sass/themes/gray.scss
@@ -1,0 +1,24 @@
+/*
+ * 沉稳主题
+ */
+
+.cherry.theme__gray {
+  --primary-color: var(--oc-blue-6);
+  --secondary-color: var(--oc-blue-0);
+  --base-font-color: var(--oc-gray-7);
+  --base-editor-bg: var(--oc-white);
+  --base-previewer-bg: var(--oc-white);
+  --base-border-color: var(--oc-gray-3);
+  --md-heading-color: var(--oc-gray-7);
+  --md-paragraph-color: var(--oc-gray-7);
+  --md-link-color: var(--primary-color);
+  --md-link-hover-color: var(--oc-blue-4);
+  --md-inline-code-color: var(--oc-red-7);
+  --md-inline-code-bg: var(--oc-gray-2);
+  --md-blockquote-bg: rgba(134, 142, 150, 0.05);
+  --md-hr-border: var(--oc-gray-3);
+  --md-table-border: var(--oc-gray-3);
+  --accordion-summary-hover-bg: var(--oc-gray-3);
+  --accordion-summary-bg: var(--oc-gray-2);
+  --accordion-summary-color: var(--oc-gray-7);
+}


### PR DESCRIPTION
有用户念旧，希望找回曾经灰灰的表格样式
<img width="783" height="286" alt="image" src="https://github.com/user-attachments/assets/6197a328-4618-4c07-b9ec-fec5a892a7af" />
