### PR TITLE
fix: #1424 改进图片工具栏定位逻辑

### DIFF
--- a/.changeset/fix-image-handler-locate.md
+++ b/.changeset/fix-image-handler-locate.md
@@ -1,0 +1,6 @@
+---
+'cherry-markdown': patch
+
+---
+
+fix: 改进图片工具栏定位逻辑

--- a/packages/cherry-markdown/src/utils/imgToolHandler.js
+++ b/packages/cherry-markdown/src/utils/imgToolHandler.js
@@ -131,23 +131,38 @@ const imgToolHandler = {
     const mouseX = event.x - previewerRect.left;
     const mouseY = event.y - previewerRect.top;
 
-    // 检查工具栏是否会超出图片边界
-    const wouldOverflowRight = mouseX + toolbarWidth > imgPosition.left + imgPosition.width;
-    const wouldOverflowBottom = mouseY + toolbarHeight > imgPosition.top + imgPosition.height;
-    const wouldOverflowLeft = mouseX < imgPosition.left;
-    const wouldOverflowTop = mouseY < imgPosition.top;
+    // 工具栏与图片边缘的间距
+    const padding = 8;
 
     let finalLeft;
     let finalTop;
 
-    if (wouldOverflowRight || wouldOverflowBottom || wouldOverflowLeft || wouldOverflowTop) {
-      // 工具栏会超出图片边界，将其放在图片正下方居中
+    if (imgPosition.width < toolbarWidth + padding * 2) {
+      // 图片宽度小于工具栏宽度，工具栏放在图片下方居中
       finalLeft = imgPosition.left + (imgPosition.width - toolbarWidth) / 2;
-      finalTop = imgPosition.top + imgPosition.height + 5;
+      finalTop = imgPosition.top + imgPosition.height + padding;
     } else {
-      // 工具栏在图片内部，使用鼠标位置
-      finalLeft = mouseX;
+      // 图片宽度足够，尝试将工具栏放在图片内部
       finalTop = mouseY;
+
+      // 检查垂直方向是否超出图片边界
+      if (mouseY < imgPosition.top + padding) {
+        finalTop = imgPosition.top + padding;
+      } else if (mouseY + toolbarHeight > imgPosition.top + imgPosition.height - padding) {
+        finalTop = imgPosition.top + imgPosition.height - toolbarHeight - padding;
+      }
+
+      // 水平方向：从鼠标位置开始，如果超出右边界就左移
+      finalLeft = mouseX;
+      if (mouseX + toolbarWidth > imgPosition.left + imgPosition.width - padding) {
+        // 右边界超出，调整到图片右边界内
+        finalLeft = imgPosition.left + imgPosition.width - toolbarWidth - padding;
+      }
+
+      // 检查左边界
+      if (finalLeft < imgPosition.left + padding) {
+        finalLeft = imgPosition.left + padding;
+      }
     }
 
     this.container.style.left = `${finalLeft}px`;

--- a/packages/cherry-markdown/src/utils/imgToolHandler.js
+++ b/packages/cherry-markdown/src/utils/imgToolHandler.js
@@ -112,11 +112,49 @@ const imgToolHandler = {
     });
 
     const previewerRect = this.previewerDom.parentNode.getBoundingClientRect();
-    this.container.style.left = `${event.x - previewerRect.left}px`;
-    this.container.style.top = `${event.y - previewerRect.top}px`;
+    const imgPosition = this.getImgPosition();
+
+    // 临时设置工具栏位置以获取其尺寸
+    this.container.style.visibility = 'hidden';
+    this.container.style.left = '0px';
+    this.container.style.top = '0px';
+
+    // 获取工具栏的尺寸
+    const toolbarRect = this.container.getBoundingClientRect();
+    const toolbarWidth = toolbarRect.width;
+    const toolbarHeight = toolbarRect.height;
+
+    // 恢复可见性
+    this.container.style.visibility = '';
+
+    // 计算鼠标位置相对于预览器的坐标
+    const mouseX = event.x - previewerRect.left;
+    const mouseY = event.y - previewerRect.top;
+
+    // 检查工具栏是否会超出图片边界
+    const wouldOverflowRight = mouseX + toolbarWidth > imgPosition.left + imgPosition.width;
+    const wouldOverflowBottom = mouseY + toolbarHeight > imgPosition.top + imgPosition.height;
+    const wouldOverflowLeft = mouseX < imgPosition.left;
+    const wouldOverflowTop = mouseY < imgPosition.top;
+
+    let finalLeft;
+    let finalTop;
+
+    if (wouldOverflowRight || wouldOverflowBottom || wouldOverflowLeft || wouldOverflowTop) {
+      // 工具栏会超出图片边界，将其放在图片正下方居中
+      finalLeft = imgPosition.left + (imgPosition.width - toolbarWidth) / 2;
+      finalTop = imgPosition.top + imgPosition.height + 5;
+    } else {
+      // 工具栏在图片内部，使用鼠标位置
+      finalLeft = mouseX;
+      finalTop = mouseY;
+    }
+
+    this.container.style.left = `${finalLeft}px`;
+    this.container.style.top = `${finalTop}px`;
 
     this.position = {
-      ...this.getImgPosition(),
+      ...imgPosition,
     };
   },
   emit(type, event = {}) {

--- a/packages/cherry-markdown/src/utils/imgToolHandler.js
+++ b/packages/cherry-markdown/src/utils/imgToolHandler.js
@@ -137,12 +137,12 @@ const imgToolHandler = {
     let finalLeft;
     let finalTop;
 
-    if (imgPosition.width < toolbarWidth + padding * 2) {
-      // 图片宽度小于工具栏宽度，工具栏放在图片下方居中
+    if (imgPosition.width < toolbarWidth + padding * 2 || imgPosition.height < toolbarHeight + padding * 2) {
+      // 图片宽度或高度小于工具栏尺寸，工具栏放在图片下方居中
       finalLeft = imgPosition.left + (imgPosition.width - toolbarWidth) / 2;
       finalTop = imgPosition.top + imgPosition.height + padding;
     } else {
-      // 图片宽度足够，尝试将工具栏放在图片内部
+      // 图片宽度、高度足够，尝试将工具栏放在图片内部
       finalTop = mouseY;
 
       // 检查垂直方向是否超出图片边界


### PR DESCRIPTION
fix #1424 

<img width="492" height="710" alt="PixPin_2025-09-01_17-45-54" src="https://github.com/user-attachments/assets/3ea27ef1-282d-4b7c-ba66-643dc18545da" />

目前的逻辑为

如果图片宽度或高度小于工具栏尺寸，工具栏放在图片下方居中

否则则尝试把工具栏放在图片中：