### PR TITLE
fix: 修复表格中的代码块 无法使用 | 符号

### DIFF
--- a/.changeset/thin-bugs-wash.md
+++ b/.changeset/thin-bugs-wash.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: #1079 修复表格中的代码块 无法使用 | 符号

--- a/packages/cherry-markdown/src/core/hooks/CodeBlock.js
+++ b/packages/cherry-markdown/src/core/hooks/CodeBlock.js
@@ -476,9 +476,10 @@ export default class CodeBlock extends ParagraphBase {
     // 表格里处理行内代码，让一个td里的行内代码语法生效，让跨td的行内代码语法失效
     $str = $str.replace(getTableRule(true), (whole, ...args) => {
       return whole
+        .replace(/\\\|/g, '~CHERRYNormalLine')
         .split('|')
         .map((oneTd) => {
-          return this.makeInlineCode(oneTd);
+          return this.makeInlineCode(oneTd).replace('~CHERRYNormalLine', '\\|');
         })
         .join('|')
         .replace(/`/g, '\\`');
@@ -516,6 +517,7 @@ export default class CodeBlock extends ParagraphBase {
         }
         let $code = code.replace(/~~not~inlineCode/g, '\\`');
         $code = this.$replaceSpecialChar($code);
+        $code = $code.replace('~CHERRYNormalLine', '|');
         $code = $code.replace(/\\/g, '\\\\');
 
         // 如果行内代码只有一个颜色值，则在code末尾追加一个颜色圆点


### PR DESCRIPTION
#1079 修复表格中的代码块 无法使用 | 符号
<img width="1429" height="317" alt="image" src="https://github.com/user-attachments/assets/ab59138f-6e02-48b4-aa93-fa4a31f17681" />
