### PR TITLE
ci: fix publish npm

### DIFF
--- a/.github/workflows/pr_merge_cherry-markdown_npm-dev.yml
+++ b/.github/workflows/pr_merge_cherry-markdown_npm-dev.yml
@@ -67,7 +67,9 @@ jobs:
         working-directory: ./packages/cherry-markdown
         run: yarn install && yarn build
 
-      - run: npm install -g npm@latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - name: npm publish
         working-directory: ./packages/cherry-markdown

--- a/.github/workflows/release-cherry-markdown-build.yaml
+++ b/.github/workflows/release-cherry-markdown-build.yaml
@@ -23,7 +23,9 @@ jobs:
           yarn
           yarn build
 
-      - run: npm install -g npm@latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - name: Publish cherry-markdown
         run: |


### PR DESCRIPTION
```bash
﻿2025-12-19T02:48:58.1246118Z ##[group]Run npm install -g npm@latest
npm install -g npm@latest
shell: /usr/bin/bash -e {0}
env:
  COMMIT_SHORT_SHA: f5e01e9
  COMMIT_MESSAGE: f5e01e9 fix: #1570 修复点击脚注列表里的标号时有js报错的问题 (#1573)
  PACKAGE_VERSION: 0.10.3-202512190243.f5e01e9
  PACKAGE_NAME: @cherry-markdown/cherry-markdown-dev
  NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
  NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: npm@11.7.0
npm error notsup Not compatible with your version of node/npm: npm@11.7.0
npm error notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.8"}
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-12-19T02_48_58_200Z-debug-0.log

```
又是node 18卡壳，node18编译后，把node切换到node24 进行OIDC 发包
