### PR TITLE
feat(sidebar): 添加侧边栏列表样式和动态高度支持

### DIFF
--- a/.changeset/tall-pots-bake.md
+++ b/.changeset/tall-pots-bake.md
@@ -1,0 +1,5 @@
+---
+"cherry-markdown": patch
+---
+
+feat(sidebar): 添加侧边栏列表样式和动态高度支持

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -522,6 +522,14 @@
   bottom: 0;
   overflow: hidden;
 
+  .cherry-sidebar-list {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 100%;
+    box-sizing: border-box;
+  }
+
   // 侧边栏按钮 非顶部工具栏
   .cherry-toolbar-button {
     height: 30px;
@@ -1460,7 +1468,7 @@
   z-index: 11;
   position: absolute;
   right: 0;
-  top: calc(var(--height-toolbar) + 120px);
+  top: calc(var(--height-toolbar) + var(--sidebar-list-height));
   height: calc(100% - 220px);
   max-height: 600px;
   width: 160px;

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -526,7 +526,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    height: 100%;
     box-sizing: border-box;
   }
 

--- a/packages/cherry-markdown/src/sass/variables/semantic.scss
+++ b/packages/cherry-markdown/src/sass/variables/semantic.scss
@@ -28,6 +28,8 @@
   --toolbar-shadow: var(--shadow-sm);
   --toolbar-split-color: var(--base-border-color);
   --toolbar-min-height: 48px; // 单行工具栏的高度
+  // 侧边栏列表高度（由 JS 动态写入），默认 120px 作为无侧栏时的回退
+  --sidebar-list-height: 120px;
 
   // 工具栏按钮
   --toolbar-btn-color: #3f4a56;

--- a/packages/cherry-markdown/src/toolbars/MenuBase.js
+++ b/packages/cherry-markdown/src/toolbars/MenuBase.js
@@ -557,6 +557,10 @@ export default class MenuBase {
    */
   static getTargetParentByButton(dom) {
     let parent = dom.parentElement;
+    // unwrap sidebar list wrapper to preserve position detection
+    if (parent && parent.classList.contains('cherry-sidebar-list')) {
+      parent = parent.parentElement;
+    }
     if (/toolbar-(left|right)/.test(parent.className)) {
       parent = parent.parentElement;
     }

--- a/packages/cherry-markdown/src/toolbars/Sidebar.js
+++ b/packages/cherry-markdown/src/toolbars/Sidebar.js
@@ -35,7 +35,6 @@ export default class Sidebar extends Toolbar {
         // 高度为 0 时保持默认 120px，不覆盖
         if (height > 0) {
           this.$cherry.wrapperDom.style.setProperty('--sidebar-list-height', `${height}px`);
-          console.log('--sidebar-list-height:', height);
         }
       }, 0);
     }

--- a/packages/cherry-markdown/src/toolbars/Sidebar.js
+++ b/packages/cherry-markdown/src/toolbars/Sidebar.js
@@ -29,14 +29,15 @@ export default class Sidebar extends Toolbar {
     list.appendChild(menus);
     this.options.dom.appendChild(list);
     // 将侧栏列表高度写入 CSS 变量，便于定位
-    if (typeof document !== 'undefined') {
-      setTimeout(() => {
+    if (typeof document !== 'undefined' && typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(() => {
         const height = list.scrollHeight;
         // 高度为 0 时保持默认 120px，不覆盖
         if (height > 0) {
           this.$cherry.wrapperDom.style.setProperty('--sidebar-list-height', `${height}px`);
         }
-      }, 0);
+      });
+      observer.observe(list);
     }
   }
 

--- a/packages/cherry-markdown/src/toolbars/Sidebar.js
+++ b/packages/cherry-markdown/src/toolbars/Sidebar.js
@@ -24,7 +24,18 @@ export default class Sidebar extends Toolbar {
   //   super(options);
   // }
   appendMenusToDom(menus) {
-    this.options.dom.appendChild(menus);
+    const list = document.createElement('div');
+    list.className = 'cherry-sidebar-list';
+    list.appendChild(menus);
+    this.options.dom.appendChild(list);
+    // 将侧栏列表高度写入 CSS 变量，便于定位
+    if (typeof document !== 'undefined') {
+      const height = list.scrollHeight;
+      // 高度为 0 时保持默认 120px，不覆盖
+      if (height > 0) {
+        document.documentElement.style.setProperty('--sidebar-list-height', `${height}px`);
+      }
+    }
   }
 
   init() {

--- a/packages/cherry-markdown/src/toolbars/Sidebar.js
+++ b/packages/cherry-markdown/src/toolbars/Sidebar.js
@@ -30,11 +30,14 @@ export default class Sidebar extends Toolbar {
     this.options.dom.appendChild(list);
     // 将侧栏列表高度写入 CSS 变量，便于定位
     if (typeof document !== 'undefined') {
-      const height = list.scrollHeight;
-      // 高度为 0 时保持默认 120px，不覆盖
-      if (height > 0) {
-        document.documentElement.style.setProperty('--sidebar-list-height', `${height}px`);
-      }
+      setTimeout(() => {
+        const height = list.scrollHeight;
+        // 高度为 0 时保持默认 120px，不覆盖
+        if (height > 0) {
+          this.$cherry.wrapperDom.style.setProperty('--sidebar-list-height', `${height}px`);
+          console.log('--sidebar-list-height:', height);
+        }
+      }, 0);
     }
   }
 

--- a/packages/cherry-markdown/src/toolbars/Sidebar.js
+++ b/packages/cherry-markdown/src/toolbars/Sidebar.js
@@ -32,8 +32,8 @@ export default class Sidebar extends Toolbar {
     if (typeof document !== 'undefined' && typeof ResizeObserver !== 'undefined') {
       const observer = new ResizeObserver(() => {
         const height = list.scrollHeight;
-        // 高度为 0 时保持默认 120px，不覆盖
-        if (height > 0) {
+        // 高度小于 40 时保持默认 120px，不覆盖
+        if (height > 40) {
           this.$cherry.wrapperDom.style.setProperty('--sidebar-list-height', `${height}px`);
         }
       });


### PR DESCRIPTION
更新侧边栏高度判断逻辑，确保高度小于 40 时保持默认值

1.
<img width="427" height="540" alt="image" src="https://github.com/user-attachments/assets/756ed166-1506-41c5-8ec3-10d5820e0830" />

2.
<img width="597" height="691" alt="image" src="https://github.com/user-attachments/assets/5739f355-e01a-4f7b-8620-cac4f2ac2053" />

3. 
<img width="378" height="597" alt="image" src="https://github.com/user-attachments/assets/8d5a9c55-88b0-4dbf-8315-8ea50714d530" />
