### PR TITLE
ci: 移除 PR 预览构建的分支限制

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main, dev]
 
 jobs:
   build:

--- a/.github/workflows/pr_preview-build.yml
+++ b/.github/workflows/pr_preview-build.yml
@@ -2,7 +2,6 @@ name: Preview Build
 
 on:
   pull_request:
-    branches: [dev, main]
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
当前所有分支接收到 pr 都可以创建预览页面和 运行 test build