### PR TITLE
feat: 新增echarts代码块插件，支持直接渲染echarts

### DIFF
--- a/.changeset/public-places-change.md
+++ b/.changeset/public-places-change.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+feat: 新增echarts代码块插件，支持直接渲染echarts

--- a/examples/assets/markdown/index.md
+++ b/examples/assets/markdown/index.md
@@ -745,6 +745,100 @@ $$
 - 如果不指定数据源，将使用系统默认的地图数据
 - 也可以通过 Cherry 配置中的 `toolbars.config.mapTable.sourceUrl` 全局配置数据源
 
+**直接渲染echarts**
+```echarts
+{
+  title: {
+    text: '利用代码块直接渲染'
+  },
+  tooltip: {
+    trigger: 'axis',
+    axisPointer: {
+      type: 'cross',
+      label: {
+        backgroundColor: '#6a7985'
+      }
+    }
+  },
+  legend: {
+    data: ['Email', 'Union Ads', 'Video Ads', 'Direct', 'Search Engine']
+  },
+  toolbox: {
+    feature: {
+      saveAsImage: {}
+    }
+  },
+  xAxis: [
+    {
+      type: 'category',
+      boundaryGap: false,
+      data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+    }
+  ],
+  yAxis: [
+    {
+      type: 'value'
+    }
+  ],
+  series: [
+    {
+      name: 'Email',
+      type: 'line',
+      stack: 'Total',
+      areaStyle: {},
+      emphasis: {
+        focus: 'series'
+      },
+      data: [120, 132, 101, 134, 90, 230, 210]
+    },
+    {
+      name: 'Union Ads',
+      type: 'line',
+      stack: 'Total',
+      areaStyle: {},
+      emphasis: {
+        focus: 'series'
+      },
+      data: [220, 182, 191, 234, 290, 330, 310]
+    },
+    {
+      name: 'Video Ads',
+      type: 'line',
+      stack: 'Total',
+      areaStyle: {},
+      emphasis: {
+        focus: 'series'
+      },
+      data: [150, 232, 201, 154, 190, 330, 410]
+    },
+    {
+      name: 'Direct',
+      type: 'line',
+      stack: 'Total',
+      areaStyle: {},
+      emphasis: {
+        focus: 'series'
+      },
+      data: [320, 332, 301, 334, 390, 330, 320]
+    },
+    {
+      name: 'Search Engine',
+      type: 'line',
+      stack: 'Total',
+      label: {
+        show: true,
+        position: 'top'
+      },
+      areaStyle: {},
+      emphasis: {
+        focus: 'series'
+      },
+      data: [820, 932, 901, 934, 1290, 1330, 1320]
+    }
+  ]
+};
+```
+
 -----
 
 ## 流程图[^不通用提醒]

--- a/examples/index.html
+++ b/examples/index.html
@@ -55,6 +55,13 @@
       const basicMd = await response.text();
       // 在Vite中使用?raw导入的文件内容已经是字符串，无需通过fetch获取
       const config = Object.assign({}, basicConfig, { value: basicMd });
+      // 引入官方库里的 Echarts 代码块插件
+      Cherry.usePlugin(Cherry.plugins.EChartsCodeBlockEngine, {
+        size: {
+          width: '100%',
+          height: '600px',
+        }
+      });
       window.cherry = new Cherry(config);
     </script>
   </body>

--- a/packages/cherry-markdown/index.html
+++ b/packages/cherry-markdown/index.html
@@ -43,6 +43,13 @@
       import Cherry from './src/index.js';
       import '@examples/assets/scripts/pinyin/pinyin_dist.js';
 
+      // 引入官方库里的 Echarts 代码块插件
+      Cherry.usePlugin(Cherry.plugins.EChartsCodeBlockEngine, {
+        size: {
+          width: '100%',
+          height: '600px',
+        }
+      });
       window.Cherry = Cherry;
 
       import indexMd from '@examples/assets/markdown/index.md?raw';

--- a/packages/cherry-markdown/src/CherryStatic.js
+++ b/packages/cherry-markdown/src/CherryStatic.js
@@ -22,6 +22,7 @@ import { createSyntaxHook, createMenuHook } from './Factory';
 import TapdTablePlugin from './addons/advance/cherry-tapd-table-plugin';
 import TapdHtmlTagPlugin from './addons/advance/cherry-tapd-html-tag-plugin';
 import TapdCheckListPlugin from './addons/advance/cherry-tapd-checklist-plugin';
+import EChartsCodeBlockEngine from './addons/advance/cherry-codeblock-echarts-plugin';
 import { isBrowser } from './utils/env';
 
 const constants = { HOOKS_TYPE_LIST };
@@ -30,6 +31,7 @@ const plugins = {
   TapdTablePlugin,
   TapdHtmlTagPlugin,
   TapdCheckListPlugin,
+  EChartsCodeBlockEngine,
 };
 const nodeIgnorePlugin = [];
 

--- a/packages/cherry-markdown/src/Previewer.js
+++ b/packages/cherry-markdown/src/Previewer.js
@@ -701,7 +701,8 @@ export default class Previewer {
               newContent[change.newIndex].dom.querySelector('.cherry-echarts-codeblock-wrapper') &&
               oldContent[change.oldIndex].dom.querySelector('.cherry-echarts-codeblock-wrapper')
             ) {
-              oldContent[change.oldIndex].dom.replaceWith(newContent[change.newIndex].dom);
+              oldContent[change.oldIndex].dom.dataset.sign = newContent[change.newIndex].dom.dataset.sign;
+              oldContent[change.oldIndex].dom.dataset.lines = newContent[change.newIndex].dom.dataset.lines;
               hasUpdate = true;
             } else if (newContent[change.newIndex].dom.querySelector('svg')) {
               throw new Error(); // SVG暂不使用patch更新

--- a/packages/cherry-markdown/src/Previewer.js
+++ b/packages/cherry-markdown/src/Previewer.js
@@ -695,6 +695,14 @@ export default class Previewer {
                 oldContent[change.oldIndex].dom.querySelector('.cherry-table'),
               );
               hasUpdate = true;
+            } else if (
+              // 处理代码块渲染echarts的特殊场景
+              newContent[change.newIndex].dom.dataset.type === 'echarts' &&
+              newContent[change.newIndex].dom.querySelector('.cherry-echarts-codeblock-wrapper') &&
+              oldContent[change.oldIndex].dom.querySelector('.cherry-echarts-codeblock-wrapper')
+            ) {
+              oldContent[change.oldIndex].dom.replaceWith(newContent[change.newIndex].dom);
+              hasUpdate = true;
             } else if (newContent[change.newIndex].dom.querySelector('svg')) {
               throw new Error(); // SVG暂不使用patch更新
             }

--- a/packages/cherry-markdown/src/addons/advance/cherry-codeblock-echarts-plugin.js
+++ b/packages/cherry-markdown/src/addons/advance/cherry-codeblock-echarts-plugin.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import mergeWith from 'lodash/mergeWith';
+import JSON5 from 'json5';
 
 export default class EChartsCodeBlockEngine {
   static install(cherryOptions, ...args) {
@@ -47,25 +48,32 @@ export default class EChartsCodeBlockEngine {
 
   render(src, sign, $engine, language) {
     if (src.trim().length <= 0) return '';
-    const chartId = `cherry-chart-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const width = this.size?.width || '100%';
     const height = this.size?.height || '300px';
     const styleStr = `width: ${width}; height: ${height};`;
     const previewerDom = $engine.$cherry.previewer.getDom();
     // 延迟到下一轮事件循环再执行
     setTimeout(() => {
-      const container = previewerDom.querySelector(`#${chartId}`);
+      const container = previewerDom.querySelector(
+        `div[data-sign="${sign}"][data-type="echarts"] .cherry-echarts-codeblock-wrapper`,
+      );
       if (!container || !this.echartsRef) return;
       try {
-        // 使用 new Function 替代 JSON.parse 以支持非标准 JSON (如带注释、key 无引号等)
-        // eslint-disable-next-line no-new-func
-        const option = new Function(`return ${src}`)();
-        const chart = this.echartsRef.init(container, null);
-        chart.setOption(option);
+        const option = JSON5.parse(src.replace(/;\s*$/, ''));
+        // 判断是否已经初始化
+        let chart = this.echartsRef.getInstanceByDom(container);
+        if (!chart) {
+          chart = this.echartsRef.init(container);
+        }
+        chart.setOption(option, true); // 增加 true 参数以强制覆盖旧配置
       } catch (error) {
-        container.innerHTML = `<div style="color: red;">Render Error: ${error.message}</div>`;
+        if ($engine.$cherry.options.engine.global.flowSessionContext) {
+          container.innerHTML = `drawing...`;
+        } else {
+          container.innerHTML = `<div style="color: red;">Render Error: ${error.message}</div>`;
+        }
       }
     }, 50);
-    return `<div id="${chartId}" style="${styleStr}" class="cherry-echarts-codeblock-wrapper"></div>`;
+    return `<div style="${styleStr}" class="cherry-echarts-codeblock-wrapper"></div>`;
   }
 }

--- a/packages/cherry-markdown/src/addons/advance/cherry-codeblock-echarts-plugin.js
+++ b/packages/cherry-markdown/src/addons/advance/cherry-codeblock-echarts-plugin.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2021 Tencent.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import mergeWith from 'lodash/mergeWith';
+
+export default class EChartsCodeBlockEngine {
+  static install(cherryOptions, ...args) {
+    if (typeof window === 'undefined' || typeof window.echarts === 'undefined') {
+      return;
+    }
+    mergeWith(cherryOptions, {
+      engine: {
+        syntax: {
+          codeBlock: {
+            customRenderer: {
+              echarts: new EChartsCodeBlockEngine(...args),
+            },
+          },
+        },
+      },
+      externals: {
+        echarts: window.echarts,
+      },
+    });
+  }
+
+  constructor(echartsOptions = {}) {
+    const { echarts, cherry, size } = echartsOptions;
+    if (!echarts && !window.echarts) {
+      throw new Error('codeblock-echarts-plugin[init]: Package echarts not found.');
+    }
+    this.size = size;
+    this.echartsRef = echarts || window.echarts; // echarts引用
+
+    // 保存Cherry实例，用于事件监听及i18n
+    this.$cherry = cherry;
+  }
+
+  render(src, sign, $engine, language) {
+    if (src.trim().length <= 0) return '';
+    const chartId = `cherry-chart-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const width = this.size?.width || '100%';
+    const height = this.size?.height || '300px';
+    const styleStr = `width: ${width}; height: ${height};`;
+    // 延迟到下一轮事件循环再执行
+    setTimeout(() => {
+      const container = document.getElementById(chartId);
+      if (!container || !this.echartsRef) return;
+      try {
+        // 使用 new Function 替代 JSON.parse 以支持非标准 JSON (如带注释、key 无引号等)
+        // eslint-disable-next-line no-new-func
+        const option = new Function(`return ${src}`)();
+        const chart = this.echartsRef.init(container);
+        chart.setOption(option);
+      } catch (error) {
+        container.innerHTML = `<div style="color: red;">Render Error: ${error.message}</div>`;
+      }
+    }, 50);
+    return `<div id="${chartId}" style="${styleStr}"></div>`;
+  }
+}

--- a/packages/cherry-markdown/src/addons/advance/cherry-codeblock-echarts-plugin.js
+++ b/packages/cherry-markdown/src/addons/advance/cherry-codeblock-echarts-plugin.js
@@ -37,15 +37,12 @@ export default class EChartsCodeBlockEngine {
   }
 
   constructor(echartsOptions = {}) {
-    const { echarts, cherry, size } = echartsOptions;
+    const { echarts, size } = echartsOptions;
     if (!echarts && !window.echarts) {
       throw new Error('codeblock-echarts-plugin[init]: Package echarts not found.');
     }
     this.size = size;
     this.echartsRef = echarts || window.echarts; // echarts引用
-
-    // 保存Cherry实例，用于事件监听及i18n
-    this.$cherry = cherry;
   }
 
   render(src, sign, $engine, language) {
@@ -54,20 +51,21 @@ export default class EChartsCodeBlockEngine {
     const width = this.size?.width || '100%';
     const height = this.size?.height || '300px';
     const styleStr = `width: ${width}; height: ${height};`;
+    const previewerDom = $engine.$cherry.previewer.getDom();
     // 延迟到下一轮事件循环再执行
     setTimeout(() => {
-      const container = document.getElementById(chartId);
+      const container = previewerDom.querySelector(`#${chartId}`);
       if (!container || !this.echartsRef) return;
       try {
         // 使用 new Function 替代 JSON.parse 以支持非标准 JSON (如带注释、key 无引号等)
         // eslint-disable-next-line no-new-func
         const option = new Function(`return ${src}`)();
-        const chart = this.echartsRef.init(container);
+        const chart = this.echartsRef.init(container, null);
         chart.setOption(option);
       } catch (error) {
         container.innerHTML = `<div style="color: red;">Render Error: ${error.message}</div>`;
       }
     }, 50);
-    return `<div id="${chartId}" style="${styleStr}"></div>`;
+    return `<div id="${chartId}" style="${styleStr}" class="cherry-echarts-codeblock-wrapper"></div>`;
   }
 }

--- a/packages/cherry-markdown/src/core/hooks/CodeBlock.js
+++ b/packages/cherry-markdown/src/core/hooks/CodeBlock.js
@@ -482,7 +482,6 @@ export default class CodeBlock extends ParagraphBase {
         $code = $code.replace(regex, '$1');
       }
 
-      // 未命中缓存，执行渲染
       let $lang = lang.trim().toLowerCase();
       // 从语言行中解析尺寸和对齐信息（如 mermaid #300px #200px #center）
       const mermaidSizeInfo = this.parseMermaidSize($lang);
@@ -509,7 +508,10 @@ export default class CodeBlock extends ParagraphBase {
           mermaidAlignClass,
         });
         if (cacheCode && cacheCode !== '') {
-          this.$codeCache(sign, cacheCode);
+          // echarts渲染的场景不再缓存，因为缓存后无法触发echarts渲染
+          if (!/^\s*echarts\s*$/.test($lang)) {
+            this.$codeCache(sign, cacheCode);
+          }
           return this.getCacheWithSpace(this.pushCache(cacheCode, sign, lines), match);
         }
         // 渲染出错则按正常code进行渲染


### PR DESCRIPTION
## 增加官方插件：代码块直接渲染echarts
```
      // 引入官方库里的 Echarts 代码块插件
      Cherry.usePlugin(Cherry.plugins.EChartsCodeBlockEngine, {
        size: {
          width: '100%',
          height: '600px',
        }
      });
      cherry = new Cherry(config);
```

## 效果如下
<img width="3627" height="1006" alt="image" src="https://github.com/user-attachments/assets/2c845df7-1511-4ad4-8185-c13309e0ba99" />
