### PR TITLE
refactor: 统一浏览器环境检测与外部依赖获取，优化全局类型声明

### DIFF
--- a/.changeset/refactor-window-access.md
+++ b/.changeset/refactor-window-access.md
@@ -1,0 +1,9 @@
+---
+'cherry-markdown': patch
+---
+
+refactor: 统一 window 对象访问方式，完善全局类型声明
+
+- 新增 `getExternal()` 工具函数，统一收口 `window.echarts`、`window.mermaid`、`window.katex`、`window.MathJax` 等外部依赖的获取逻辑，内置 `isBrowser` 守卫，SSR 环境下安全返回 `undefined`
+- `global.d.ts` 不再 import mermaid/katex 等第三方包，改为只声明 cherry-markdown 自身挂载的全局类型（`window.Cherry`、`window.CherryEngine`、插件等），用户无需安装未使用的可选依赖即可获得类型支持
+- 新增 `CherryStream`、`CherryEngine`、`CherryCodeBlockMermaidPlugin`、`CherryCodeBlockPlantumlPlugin` 全局类型声明

--- a/.changeset/refactor-window-access.md
+++ b/.changeset/refactor-window-access.md
@@ -2,8 +2,8 @@
 'cherry-markdown': patch
 ---
 
-refactor: 统一 window 对象访问方式，完善全局类型声明
+refactor(core): 统一外部依赖获取方式，优化全局类型声明
 
-- 新增 `getExternal()` 工具函数，统一收口 `window.echarts`、`window.mermaid`、`window.katex`、`window.MathJax` 等外部依赖的获取逻辑，内置 `isBrowser` 守卫，SSR 环境下安全返回 `undefined`
-- `global.d.ts` 不再 import mermaid/katex 等第三方包，改为只声明 cherry-markdown 自身挂载的全局类型（`window.Cherry`、`window.CherryEngine`、插件等），用户无需安装未使用的可选依赖即可获得类型支持
-- 新增 `CherryStream`、`CherryEngine`、`CherryCodeBlockMermaidPlugin`、`CherryCodeBlockPlantumlPlugin` 全局类型声明
+- 统一 echarts、mermaid、katex、MathJax 等外部依赖的获取逻辑，SSR 环境下安全返回 `undefined`，不再直接访问 `window` 对象
+- `global.d.ts` 移除对 mermaid/katex 等第三方包的 import，用户引入类型时不再需要安装未使用的可选依赖
+- 新增 `window.Cherry`、`window.CherryStream`、`window.CherryEngine`、`window.CherryCodeBlockMermaidPlugin`、`window.CherryCodeBlockPlantumlPlugin` 全局类型声明

--- a/packages/cherry-markdown/package.json
+++ b/packages/cherry-markdown/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "types"
+    "types",
+    "!types/env.d.ts"
   ],
   "sideEffects": [
     "./dist/*.css"

--- a/packages/cherry-markdown/src/Engine.js
+++ b/packages/cherry-markdown/src/Engine.js
@@ -27,6 +27,7 @@ import AsyncRenderHandler from './utils/async-render-handler';
 import UrlCache from './UrlCache';
 import htmlParser from './utils/htmlparser';
 import { isBrowser } from './utils/env';
+import { getExternal } from './utils/external';
 import * as htmlparser2 from 'htmlparser2';
 import LRUCache from './utils/LRUCache';
 import { loadCSS, loadScript } from './utils/dom';
@@ -125,7 +126,7 @@ export default class Engine {
     }
     if (syntax.mathBlock.engine === 'MathJax' || syntax.inlineMath.engine === 'MathJax') {
       // 已经加载过MathJax
-      if (externals.MathJax || window.MathJax) {
+      if (externals.MathJax || getExternal('MathJax')) {
         return;
       }
       configureMathJax(plugins);
@@ -134,20 +135,22 @@ export default class Engine {
       }
     }
     if (syntax.mathBlock.engine === 'katex' || syntax.inlineMath.engine === 'katex') {
-      // @ts-ignore
-      if (window.katex) {
+      const katexInstance = /** @type {import('./types/global').KatexRuntime | undefined} */ (getExternal('katex'));
+      if (katexInstance) {
         return;
       }
       syntax.mathBlock.css && loadCSS(syntax.mathBlock.css, 'katex-css');
       if (syntax.mathBlock.src) {
         loadScript(syntax.mathBlock.src, 'katex-js').then(() => {
+          const resolvedKatex = /** @type {import('./types/global').KatexRuntime} */ (getExternal('katex'));
+          if (!resolvedKatex) { return; }
           // 先更新预览区域
           this.$cherry.previewer
             .getDom()
             .querySelectorAll('.cherry-katex-need-render')
             .forEach((el) => {
               const displayMode = el.classList.contains('Cherry-Math');
-              el.innerHTML = window.katex.renderToString(decodeURIComponent(el.getAttribute('data-content')), {
+              el.innerHTML = resolvedKatex.renderToString(decodeURIComponent(el.getAttribute('data-content')), {
                 throwOnError: false,
                 displayMode,
               });
@@ -158,12 +161,11 @@ export default class Engine {
           this.asyncRenderHandler.md = this.asyncRenderHandler.md.replace(
             /<(div|span) data-sign="([^"]+?)" class="([^"]+?) cherry-katex-need-render" ([^>]+? data-lines="[^"]+?") data-content="([\s\S]+?)"><\/\1>/g,
             (match, domName, sign, className, attrs, content) => {
-              const displayMode = domName === 'div';
-              const key = domName === 'div' ? `math-block-${sign}` : `math-inline-${sign}`;
-              // @ts-ignore
-              const html = window.katex.renderToString(decodeURIComponent(content), {
+              const isDisplayMode = domName === 'div';
+              const key = isDisplayMode ? `math-block-${sign}` : `math-inline-${sign}`;
+              const html = resolvedKatex.renderToString(decodeURIComponent(content), {
                 throwOnError: false,
-                displayMode,
+                displayMode: isDisplayMode,
               });
               needDoneKeys.push(key);
               return `<${domName} data-sign="${sign}" class="${className}" ${attrs}>${html}</${domName}>`;

--- a/packages/cherry-markdown/src/Engine.js
+++ b/packages/cherry-markdown/src/Engine.js
@@ -135,15 +135,17 @@ export default class Engine {
       }
     }
     if (syntax.mathBlock.engine === 'katex' || syntax.inlineMath.engine === 'katex') {
-      const katexInstance = /** @type {import('./types/global').KatexRuntime | undefined} */ (getExternal('katex'));
+      const katexInstance = /** @type {import('katex').default | undefined} */ (getExternal('katex'));
       if (katexInstance) {
         return;
       }
       syntax.mathBlock.css && loadCSS(syntax.mathBlock.css, 'katex-css');
       if (syntax.mathBlock.src) {
         loadScript(syntax.mathBlock.src, 'katex-js').then(() => {
-          const resolvedKatex = /** @type {import('./types/global').KatexRuntime} */ (getExternal('katex'));
-          if (!resolvedKatex) { return; }
+          const resolvedKatex = /** @type {import('katex').default} */ (getExternal('katex'));
+          if (!resolvedKatex) {
+            return;
+          }
           // 先更新预览区域
           this.$cherry.previewer
             .getDom()

--- a/packages/cherry-markdown/src/addons/advance/cherry-codeblock-echarts-plugin.js
+++ b/packages/cherry-markdown/src/addons/advance/cherry-codeblock-echarts-plugin.js
@@ -15,10 +15,12 @@
  */
 import mergeWith from 'lodash/mergeWith';
 import JSON5 from 'json5';
+import { getExternal } from '@/utils/external';
 
 export default class EChartsCodeBlockEngine {
   static install(cherryOptions, ...args) {
-    if (typeof window === 'undefined' || typeof window.echarts === 'undefined') {
+    const globalEcharts = /** @type {import('echarts').ECharts | undefined} */ (getExternal('echarts'));
+    if (!globalEcharts) {
       return;
     }
     mergeWith(cherryOptions, {
@@ -32,18 +34,20 @@ export default class EChartsCodeBlockEngine {
         },
       },
       externals: {
-        echarts: window.echarts,
+        echarts: globalEcharts,
       },
     });
   }
 
   constructor(echartsOptions = {}) {
-    const { echarts, size } = echartsOptions;
-    if (!echarts && !window.echarts) {
+    const { echarts } = echartsOptions;
+    const globalEcharts = /** @type {import('echarts').ECharts | undefined} */ (getExternal('echarts'));
+    const resolvedEcharts = echarts || globalEcharts;
+    if (!resolvedEcharts) {
       throw new Error('codeblock-echarts-plugin[init]: Package echarts not found.');
     }
-    this.size = size;
-    this.echartsRef = echarts || window.echarts; // echarts引用
+    this.size = echartsOptions.size;
+    this.echartsRef = resolvedEcharts; // echarts引用
   }
 
   render(src, sign, $engine, language) {

--- a/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js
+++ b/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js
@@ -15,6 +15,7 @@
  */
 import mergeWith from 'lodash/mergeWith';
 import Logger from '@/Logger';
+import { getExternal } from '@/utils/external';
 
 // 主题与常量集中管理
 const THEME = {
@@ -71,11 +72,13 @@ export default class EChartsTableEngine {
 
   constructor(echartsOptions = {}) {
     const { echarts, cherryOptions, cherry, ...options } = echartsOptions;
-    if (!echarts && !window.echarts) {
+    const globalEcharts = getExternal('echarts');
+    const resolvedEcharts = echarts || globalEcharts;
+    if (!resolvedEcharts) {
       throw new Error('table-echarts-plugin[init]: Package echarts not found.');
     }
     this.options = { ...DEFAULT_OPTIONS, ...(options || {}) };
-    this.echartsRef = echarts || window.echarts; // echarts引用
+    this.echartsRef = /** @type {*} */ (resolvedEcharts); // echarts引用
     this.dom = null;
 
     // 保存Cherry配置，用于获取地图数据源URL

--- a/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js
+++ b/packages/cherry-markdown/src/addons/advance/cherry-table-echarts-plugin.js
@@ -16,6 +16,7 @@
 import mergeWith from 'lodash/mergeWith';
 import Logger from '@/Logger';
 import { getExternal } from '@/utils/external';
+import { isBrowser } from '@/utils/env';
 
 // 主题与常量集中管理
 const THEME = {
@@ -44,7 +45,7 @@ const DEFAULT_OPTIONS = {
 
 export default class EChartsTableEngine {
   static install(cherryOptions, ...args) {
-    if (typeof window === 'undefined') {
+    if (!isBrowser()) {
       Logger.warn('echarts-table-engine only works in browser.');
       mergeWith(cherryOptions, {
         engine: {
@@ -1327,7 +1328,7 @@ const MapChartLoadingOptionsHandler = {
     const { engine } = options;
     // console.log('Rendering map chart:', tableObject);
 
-    return typeof window.echarts === 'undefined'
+    return !getExternal('echarts')
       ? {
           title: {
             text: `${engine.cherry.locale.chartRenderError} : ${engine.cherry.locale.chartLibraryNotLoadedTip}`,
@@ -1465,7 +1466,7 @@ const MapChartOptionsHandler = {
 
     // 用户指定了新的地图数据源，检查是否与已注册的地图源匹配
     if (userMapSource) {
-      if (window.echarts && window.echarts.getMap && window.echarts.getMap(userMapSource)) {
+      if (getExternal('echarts')?.getMap?.(userMapSource)) {
         // 用户指定数据源已注册，直接使用
         return generateOptions(MapChartCompleteOptionsHandler, tableObject, options);
       }
@@ -1479,7 +1480,7 @@ const MapChartOptionsHandler = {
     let registeredMapSource = null;
 
     for (const source of possibleMapSources) {
-      if (window.echarts && window.echarts.getMap && window.echarts.getMap(source)) {
+      if (getExternal('echarts')?.getMap?.(source)) {
         isMapRegistered = true;
         registeredMapSource = source;
         break;
@@ -1535,7 +1536,7 @@ const MapChartOptionsHandler = {
 
     this.$fetchMapData(url)
       .then((geoJson) => {
-        window.echarts.registerMap(url, geoJson);
+        getExternal('echarts')?.registerMap?.(url, geoJson);
         // console.log(`地图数据加载成功！来源: ${url}`);
         this.$refreshMapChart(options.chartId, url, options.engine);
         return geoJson;

--- a/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
+++ b/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
@@ -116,19 +116,22 @@ export default class MermaidCodeEngine {
    */
   constructor(mermaidOptions = {}) {
     const { mermaid, mermaidAPI } = mermaidOptions;
+    const browserMermaid = isBrowser() ? window.mermaid : null;
+    const browserMermaidAPI = isBrowser() ? window.mermaidAPI : null;
     if (
       !mermaidAPI &&
-      !window.mermaidAPI &&
+      !browserMermaidAPI &&
       (!mermaid || !mermaid.mermaidAPI) &&
-      (!window.mermaid || !window.mermaid.mermaidAPI)
+      (!browserMermaid || !browserMermaid.mermaidAPI)
     ) {
       throw new Error('code-block-mermaid-plugin[init]: Package mermaid or mermaidAPI not found.');
     }
     this.options = { ...DEFAULT_OPTIONS, ...(mermaidOptions || {}) };
-    this.mermaidAPIRefs = mermaidAPI || window.mermaidAPI || mermaid.mermaidAPI || window.mermaid.mermaidAPI;
+    this.mermaidAPIRefs =
+      mermaidAPI || browserMermaidAPI || mermaid.mermaidAPI || (browserMermaid && browserMermaid.mermaidAPI);
     if (this.isAsyncRenderVersion()) {
       // 异步渲染时，只有 mermaid.render 有队列优化，使用 mermaidAPI 会导致渲染出错
-      this.mermaidAPIRefs = mermaid || window.mermaid || this.mermaidAPIRefs;
+      this.mermaidAPIRefs = mermaid || browserMermaid || this.mermaidAPIRefs;
     }
     delete this.options.mermaid;
     delete this.options.mermaidAPI;

--- a/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
+++ b/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
@@ -15,6 +15,7 @@
  */
 import mergeWith from 'lodash/mergeWith';
 import { isBrowser } from '@/utils/env';
+import { getExternal } from '@/utils/external';
 
 const CHART_TYPES = [
   'flowchart',
@@ -117,8 +118,8 @@ export default class MermaidCodeEngine {
   constructor(mermaidOptions = {}) {
     const { mermaid, mermaidAPI } = mermaidOptions;
     // 兼容 v9（有 mermaidAPI 子对象）和 v10+（统一顶层对象）
-    const browserMermaid = isBrowser() ? window.mermaid : null;
-    const browserMermaidAPI = isBrowser() ? window.mermaidAPI : null;
+    const browserMermaid = getExternal('mermaid');
+    const browserMermaidAPI = getExternal('mermaidAPI');
     const resolvedMermaid = mermaid || browserMermaid;
     const resolvedMermaidAPI =
       mermaidAPI || browserMermaidAPI || (resolvedMermaid && resolvedMermaid.mermaidAPI) || null;

--- a/packages/cherry-markdown/src/index.core.js
+++ b/packages/cherry-markdown/src/index.core.js
@@ -17,10 +17,10 @@ import Cherry from './Cherry';
 
 import SyntaxHookBase from './core/SyntaxBase';
 import MenuHookBase from './toolbars/MenuBase';
+import { isBrowser } from './utils/env';
 
 // in browser
-if (window) {
-  // @ts-ignore
+if (isBrowser()) {
   window.Cherry = Cherry;
 }
 

--- a/packages/cherry-markdown/src/index.stream.js
+++ b/packages/cherry-markdown/src/index.stream.js
@@ -16,10 +16,10 @@
 import CherryStream from './CherryStream';
 
 import SyntaxHookBase from './core/SyntaxBase';
+import { isBrowser } from './utils/env';
 
 // in browser
-if (typeof window !== 'undefined') {
-  // @ts-ignore
+if (isBrowser()) {
   window.Cherry = CherryStream;
 }
 

--- a/packages/cherry-markdown/src/toolbars/Toc.js
+++ b/packages/cherry-markdown/src/toolbars/Toc.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { createElement } from '../utils/dom';
+import { isBrowser } from '../utils/env';
 /**
  * 悬浮目录
  */
@@ -127,7 +128,7 @@ export default class Toc {
       this.$switchModel('full');
       this.setModelToLocalStorage('full');
     });
-    if (window) {
+    if (isBrowser()) {
       window.addEventListener('resize', () => {
         this.$switchModel(this.model);
       });

--- a/packages/cherry-markdown/src/toolbars/hooks/Export.js
+++ b/packages/cherry-markdown/src/toolbars/hooks/Export.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import MenuBase from '@/toolbars/MenuBase';
+import { isBrowser } from '@/utils/env';
 
 export default class Export extends MenuBase {
   constructor($cherry) {
@@ -24,8 +25,8 @@ export default class Export extends MenuBase {
 
     this.subMenuConfig = [];
 
-    // window.print 可用时 才显示 “导出 PDF” 方式
-    if (typeof window !== 'undefined' && typeof window.print === 'function') {
+    // window.print 可用时 才显示 "导出 PDF" 方式
+    if (isBrowser() && typeof window.print === 'function') {
       this.subMenuConfig.push({ noIcon: true, name: 'exportToPdf', onclick: this.bindSubClick.bind(this, 'pdf') });
     }
 
@@ -54,7 +55,7 @@ export default class Export extends MenuBase {
     previewer.refresh(html);
     previewer.export(type);
     // 导出完成后，发送导出完成的信号
-    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    if (isBrowser() && typeof window.dispatchEvent === 'function') {
       const ev = new CustomEvent('cherry:export:done', { detail: { type } });
       window.dispatchEvent(ev);
     }

--- a/packages/cherry-markdown/src/utils/copy.js
+++ b/packages/cherry-markdown/src/utils/copy.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { isBrowser } from './env';
+
 /**
  * 复制内容到剪贴板
  * @param {string} [text] - 可选的纯文本内容 (text/plain)
@@ -27,7 +29,7 @@ export async function copyToClip(text, html) {
     throw new Error('没有提供任何内容进行复制');
   }
 
-  if (navigator.clipboard && window.ClipboardItem) {
+  if (isBrowser() && navigator.clipboard && window.ClipboardItem) {
     try {
       /** @type {Record<string, Blob>} */
       const clipboardItems = {};

--- a/packages/cherry-markdown/src/utils/external.js
+++ b/packages/cherry-markdown/src/utils/external.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2021 Tencent.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isBrowser } from './env';
+
+/**
+ * 安全获取 window 上的外部依赖（如 echarts、katex、MathJax、mermaid）
+ *
+ * 解决的问题：
+ * 1. SSR / 非浏览器环境安全：内部已做 isBrowser 守卫，调用方无需重复判断
+ * 2. 统一获取逻辑：避免各处散落 `window.xxx ?? externals?.xxx` 的重复代码
+ * 3. 类型安全：返回值带有正确的类型标注
+ *
+ * @template T - 依赖的类型
+ * @param {string} name - window 上的属性名，如 'echarts'、'katex'
+ * @param {T} [externalsValue] - 外部注入的备选值（优先使用）
+ * @returns {T | undefined} 找到的依赖实例，或 undefined
+ */
+export function getExternal(name, externalsValue) {
+  // 优先使用外部注入的值（通过 CherryMarkdown options.externals 传入）
+  if (externalsValue !== undefined) {
+    return externalsValue;
+  }
+  // 其次从 window 全局对象获取（SSR 安全）
+  if (!isBrowser()) {
+    return undefined;
+  }
+  return window[name];
+}
+
+export default {};

--- a/packages/cherry-markdown/src/utils/formulaUtilsHandler.js
+++ b/packages/cherry-markdown/src/utils/formulaUtilsHandler.js
@@ -19,6 +19,7 @@ import { canvas2img } from '@/utils/export';
 import { copyToClip } from '@/utils/copy';
 import { unescapeHTMLSpecialChar } from '@/utils/sanitize';
 import MathBlock from '@/core/hooks/MathBlock';
+import { getExternal } from '@/utils/external';
 
 export default class FormulaHandler {
   /** @type{HTMLElement} */
@@ -227,8 +228,9 @@ export default class FormulaHandler {
               // @ts-ignore
               const hook = this.editor.$cherry.engine.hooks.paragraph.find((hook) => hook instanceof MathBlock);
               if (hook && hook.engine === 'MathJax') {
-                window.MathJax?.texReset();
-                window.MathJax?.tex2mmlPromise?.(formulaCode, { display: true }).then((mml) => {
+                const mj = /** @type {import('./types/global').MathJaxRuntime | undefined} */ (getExternal('MathJax'));
+                mj?.texReset?.();
+                mj?.tex2mmlPromise?.(formulaCode, { display: true }).then((mml) => {
                   if (name === 'mathml') {
                     copyToClip(mml);
                   } else {
@@ -236,8 +238,9 @@ export default class FormulaHandler {
                   }
                 });
               } else if (hook && hook.engine === 'katex') {
-                if (window.katex) {
-                  const html = window.katex.renderToString(formulaCode, {
+                const katexInstance = /** @type {import('./types/global').KatexRuntime | undefined} */ (getExternal('katex'));
+                if (katexInstance) {
+                  const html = katexInstance.renderToString(formulaCode, {
                     throwOnError: false,
                     displayMode: true,
                     output: 'mathml',

--- a/packages/cherry-markdown/src/utils/formulaUtilsHandler.js
+++ b/packages/cherry-markdown/src/utils/formulaUtilsHandler.js
@@ -228,7 +228,7 @@ export default class FormulaHandler {
               // @ts-ignore
               const hook = this.editor.$cherry.engine.hooks.paragraph.find((hook) => hook instanceof MathBlock);
               if (hook && hook.engine === 'MathJax') {
-                const mj = /** @type {import('./types/global').MathJaxRuntime | undefined} */ (getExternal('MathJax'));
+                const mj = getExternal('MathJax');
                 mj?.texReset?.();
                 mj?.tex2mmlPromise?.(formulaCode, { display: true }).then((mml) => {
                   if (name === 'mathml') {
@@ -238,7 +238,7 @@ export default class FormulaHandler {
                   }
                 });
               } else if (hook && hook.engine === 'katex') {
-                const katexInstance = /** @type {import('./types/global').KatexRuntime | undefined} */ (getExternal('katex'));
+                const katexInstance = /** @type {import('katex').default | undefined} */ (getExternal('katex'));
                 if (katexInstance) {
                   const html = katexInstance.renderToString(formulaCode, {
                     throwOnError: false,

--- a/packages/cherry-markdown/src/utils/lazyLoadImg.js
+++ b/packages/cherry-markdown/src/utils/lazyLoadImg.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { isBrowser } from './env';
+
 /**
  * 懒加载图片
  *
@@ -131,7 +133,7 @@ export default class LazyLoadImg {
     const imgs = this.previewerDom.querySelectorAll('img[data-src]');
     const { height, top } = this.previewerDom.getBoundingClientRect();
     const previewerHeight = height + top + 100; // 冗余一定高度用于提前加载
-    const windowsHeight = window?.innerHeight ?? 0 + 100; // 浏览器的视口高度
+    const windowsHeight = isBrowser() ? window.innerHeight + 100 : 0; // 浏览器的视口高度
     const maxHeight = Math.min(previewerHeight, windowsHeight); // 目标视区高度一定是小于浏览器视口高度的，也一定是小于预览区高度的
     const minHeight = top - 30; // 计算顶部高度时，需要预加载一行高
     const { autoLoadImgNum } = this.options;

--- a/packages/cherry-markdown/src/utils/mathjax.js
+++ b/packages/cherry-markdown/src/utils/mathjax.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { isBrowser } from './env';
+import { getExternal } from './external';
 import { PUNCTUATION } from './regexp';
 import { escapeHTMLSpecialChar } from './sanitize';
 
@@ -21,54 +22,53 @@ import { escapeHTMLSpecialChar } from './sanitize';
  * 装饰器，挂载对应的模块到实例上
  */
 export function LoadMathModule() {
-  if (!isBrowser()) {
-    return;
-  }
-  const self = /** @type {import('../core/SyntaxBase').default & { katex: any; MathJax: any }} */ (this);
-  self.katex = self.$externals?.katex ?? window.katex;
-  self.MathJax = self.$externals?.MathJax ?? window.MathJax;
+  const self = /** @type {import('../core/SyntaxBase').default & { katex?: unknown; MathJax?: unknown }} */ (this);
+  self.katex = getExternal('katex', self.$externals?.katex);
+  self.MathJax = getExternal('MathJax', self.$externals?.MathJax);
 }
 
 export const configureMathJax = (usePlugins) => {
   if (!isBrowser()) {
-    // console.log('mathjax disabled');
     return;
   }
   const plugins = usePlugins
     ? ['input/asciimath', '[tex]/noerrors', '[tex]/cancel', '[tex]/color', '[tex]/boldsymbol', 'ui/safe']
     : ['ui/safe'];
-  // @ts-ignore
-  window.MathJax = {
-    startup: {
-      elements: ['.Cherry-Math', '.Cherry-InlineMath'],
-      typeset: true,
-    },
-    tex: {
-      inlineMath: [
-        ['$', '$'],
-        ['\\(', '\\)'],
-      ],
-      displayMath: [
-        ['$$', '$$'],
-        ['\\[', '\\]'],
-      ],
-      tags: 'ams',
-      packages: { '[+]': ['noerrors', 'cancel', 'color'] },
-      macros: {
-        bm: ['{\\boldsymbol{#1}}', 1],
+  // 使用 getExternal 确保 SSR 安全（虽然 configureMathJax 上面已守卫，但保持一致性）
+  const mathJaxTarget = /** @type {Record<string, unknown>} */ (getExternal('MathJax'));
+  if (mathJaxTarget) {
+    Object.assign(mathJaxTarget, {
+      startup: {
+        elements: ['.Cherry-Math', '.Cherry-InlineMath'],
+        typeset: true,
       },
-    },
-    options: {
-      skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code', 'a'],
-      ignoreHtmlClass: 'tex2jax_ignore',
-      processHtmlClass: 'tex2jax_process',
-      // 关闭 mathjax 菜单
-      enableMenu: false,
-    },
-    loader: {
-      load: plugins,
-    },
-  };
+      tex: {
+        inlineMath: [
+          ['$', '$'],
+          ['\\(', '\\)'],
+        ],
+        displayMath: [
+          ['$$', '$$'],
+          ['\\[', '\\]'],
+        ],
+        tags: 'ams',
+        packages: { '[+]': ['noerrors', 'cancel', 'color'] },
+        macros: {
+          bm: ['{\\boldsymbol{#1}}', 1],
+        },
+      },
+      options: {
+        skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code', 'a'],
+        ignoreHtmlClass: 'tex2jax_ignore',
+        processHtmlClass: 'tex2jax_process',
+        // 关闭 mathjax 菜单
+        enableMenu: false,
+      },
+      loader: {
+        load: plugins,
+      },
+    });
+  }
 };
 
 const noEscape = ['&', '<', '>', '"', "'"]; // 需要转换为HTML实体字符的符号

--- a/packages/cherry-markdown/src/utils/shortcutKey.js
+++ b/packages/cherry-markdown/src/utils/shortcutKey.js
@@ -1,3 +1,5 @@
+import { isBrowser } from './env';
+
 // 检测是否是 Mac 平台
 export const mac = typeof navigator !== 'undefined' ? /Mac/.test(navigator.platform) : false;
 
@@ -170,10 +172,12 @@ export const keyStackIsModifierkeys = (keyStack) => {
 };
 
 export const setDisableShortcutKey = (nameSpace, value = 'disable') => {
+  if (!isBrowser()) return;
   window.localStorage.setItem(`${nameSpace}-disable-cherry-shortcut-key`, value);
 };
 
 export const isEnableShortcutKey = (nameSpace) => {
+  if (!isBrowser()) return true;
   const disableShortcutKeyStorage = window.localStorage.getItem(`${nameSpace}-disable-cherry-shortcut-key`);
   if (disableShortcutKeyStorage === 'disable') {
     return false;
@@ -187,6 +191,7 @@ export const isEnableShortcutKey = (nameSpace) => {
  * @returns {void}
  */
 export const clearStorageKeyMap = (nameSpace) => {
+  if (!isBrowser()) return;
   window.localStorage.removeItem(`${nameSpace}-cherry-shortcut-keymap`);
 };
 
@@ -200,7 +205,8 @@ export const storageKeyMap = (nameSpace, keyMap) => {
   if (!keyMap || typeof keyMap !== 'object') {
     throw new Error('keyMap must be a object');
   }
-  return window.localStorage.setItem(`${nameSpace}-cherry-shortcut-keymap`, JSON.stringify(keyMap));
+  if (!isBrowser()) return;
+  window.localStorage.setItem(`${nameSpace}-cherry-shortcut-keymap`, JSON.stringify(keyMap));
 };
 
 /**
@@ -209,6 +215,7 @@ export const storageKeyMap = (nameSpace, keyMap) => {
  * @returns
  */
 export const getStorageKeyMap = (nameSpace) => {
+  if (!isBrowser()) return null;
   const shortcutKeyMapStorage = window.localStorage.getItem(`${nameSpace}-cherry-shortcut-keymap`);
   if (shortcutKeyMapStorage) {
     try {

--- a/packages/cherry-markdown/tsconfig.json
+++ b/packages/cherry-markdown/tsconfig.json
@@ -37,7 +37,7 @@
   ],
   "files": [
     "types/codemirror.d.ts",
-    "types/global.d.ts",
+    "types/env.d.ts",
     "types/index.d.ts"
   ]
 }

--- a/packages/cherry-markdown/types/env.d.ts
+++ b/packages/cherry-markdown/types/env.d.ts
@@ -10,6 +10,7 @@ import katex from 'katex';
 import type * as EChartsType from 'echarts';
 import type Cherry from '../src/Cherry';
 import type CherryStream from '../src/CherryStream';
+import type CherryEngine from '../src/index.engine.core';
 
 // ─── 全局类型扩展 ─────────────────────────────────────────
 // 注：global.d.ts 也声明了 Window.Cherry（用户面向，仅 typeof Cherry）。
@@ -28,6 +29,13 @@ declare global {
      * - 在 index.stream.js 入口中挂载为精简版 CherryStream 类
      */
     Cherry?: typeof Cherry | typeof CherryStream;
+
+    /**
+     * Cherry Markdown 引擎构造函数。
+     * - 在 index.engine.js 和 index.engine.core.js 入口中挂载
+     * - 仅包含核心引擎，不包含编辑器 UI
+     */
+    CherryEngine?: typeof CherryEngine;
 
     /** mermaid 实例（v9+ 均通过顶层对象访问） */
     mermaid?: typeof Mermaid;

--- a/packages/cherry-markdown/types/env.d.ts
+++ b/packages/cherry-markdown/types/env.d.ts
@@ -1,0 +1,51 @@
+/**
+ * 开发环境类型声明
+ *
+ * @remarks 此文件仅供 cherry-markdown 项目内部开发使用，
+ * 不随 npm publish 发布给最终用户（通过 .npmignore 排除）。
+ *
+ * 直接 import 可选依赖的真实类型，提供完整的类型推断。
+ */
+
+import Mermaid from 'mermaid';
+import katex from 'katex';
+import type * as EChartsType from 'echarts';
+import type Cherry from '../src/Cherry';
+import type CherryStream from '../src/CherryStream';
+
+// 标记为 ES module，使 declare global 生效
+export {};
+
+declare global {
+  const BUILD_ENV: string;
+  interface Window {
+    // for IE
+    clipboardData: ClipboardEvent['clipboardData'];
+
+    /**
+     * Cherry Markdown 编辑器构造函数。
+     * - 在 index.core.js 入口中挂载为完整版 Cherry 类
+     * - 在 index.stream.js 入口中挂载为精简版 CherryStream 类
+     */
+    Cherry?: typeof Cherry | typeof CherryStream;
+
+    /**
+     * mermaid 实例（v9+ 均通过顶层对象访问）
+     */
+    mermaid?: typeof Mermaid;
+
+    /**
+     * @deprecated v10+ 已废弃。v9 及以下版本的独立 mermaidAPI 子对象。
+     */
+    mermaidAPI?: (typeof Mermaid)['mermaidAPI'];
+
+    /** echarts 实例 */
+    echarts?: EChartsType.ECharts;
+
+    /** MathJax 实例（MathJax 没有标准 npm 类型包，使用 any） */
+    MathJax?: any;
+
+    /** katex 实例 */
+    katex?: typeof katex;
+  }
+}

--- a/packages/cherry-markdown/types/env.d.ts
+++ b/packages/cherry-markdown/types/env.d.ts
@@ -2,9 +2,7 @@
  * 开发环境类型声明
  *
  * @remarks 此文件仅供 cherry-markdown 项目内部开发使用，
- * 不随 npm publish 发布给最终用户（通过 .npmignore 排除）。
- *
- * 直接 import 可选依赖的真实类型，提供完整的类型推断。
+ * 不随 npm publish 发布给最终用户（通过 package.json files 排除）。
  */
 
 import Mermaid from 'mermaid';
@@ -13,8 +11,10 @@ import type * as EChartsType from 'echarts';
 import type Cherry from '../src/Cherry';
 import type CherryStream from '../src/CherryStream';
 
-// 标记为 ES module，使 declare global 生效
-export {};
+// ─── 全局类型扩展 ─────────────────────────────────────────
+// 注：global.d.ts 也声明了 Window.Cherry（用户面向，仅 typeof Cherry）。
+// 两者不冲突——global.d.ts 不在 tsconfig files 中，开发时不参与编译。
+// env.d.ts 的声明使用联合类型，覆盖 index.core.js 和 index.stream.js 两个入口。
 
 declare global {
   const BUILD_ENV: string;
@@ -29,21 +29,29 @@ declare global {
      */
     Cherry?: typeof Cherry | typeof CherryStream;
 
-    /**
-     * mermaid 实例（v9+ 均通过顶层对象访问）
-     */
+    /** mermaid 实例（v9+ 均通过顶层对象访问） */
     mermaid?: typeof Mermaid;
 
-    /**
-     * @deprecated v10+ 已废弃。v9 及以下版本的独立 mermaidAPI 子对象。
-     */
+    /** @deprecated v10+ 已废弃。v9 及以下版本的独立 mermaidAPI 子对象。 */
     mermaidAPI?: (typeof Mermaid)['mermaidAPI'];
 
     /** echarts 实例 */
     echarts?: EChartsType.ECharts;
 
-    /** MathJax 实例（MathJax 没有标准 npm 类型包，使用 any） */
-    MathJax?: any;
+    /**
+     * MathJax v3 实例
+     * @remarks mathjax v3 无标准 npm 类型包，@types/mathjax 仅覆盖 v2 API。
+     * 此处内联声明项目实际使用的 API 子集。
+     */
+    MathJax?: {
+      texReset?(): void;
+      tex2mmlPromise?(tex: string, opts?: { display: boolean }): Promise<string>;
+      startup?: { elements?: string[]; typeset?: boolean; [k: string]: unknown };
+      tex?: Record<string, unknown>;
+      options?: Record<string, unknown>;
+      loader?: { load?: string[] };
+      [k: string]: unknown;
+    };
 
     /** katex 实例 */
     katex?: typeof katex;

--- a/packages/cherry-markdown/types/global.d.ts
+++ b/packages/cherry-markdown/types/global.d.ts
@@ -21,6 +21,8 @@
  */
 
 import type Cherry from '../dist/types/Cherry';
+import type CherryStream from '../dist/types/CherryStream';
+import type CherryEngine from '../dist/types/index.engine.core';
 import type MermaidCodeEngine from '../dist/types/addons/cherry-code-block-mermaid-plugin';
 import type PlantUMLCodeEngine from '../dist/types/addons/cherry-code-block-plantuml-plugin';
 
@@ -35,14 +37,30 @@ declare global {
      * - 完整版（cherry-markdown.js / cherry-markdown.core.js）→ `Cherry`
      * - 流式版（cherry-markdown.stream.js）→ `CherryStream`
      *
-     * 默认类型为完整版 `Cherry`，如需精确类型可自行 narrowing。
-     *
      * @example
      * ```ts
      * const cherry = new window.Cherry({ id: 'markdown' });
      * ```
      */
-    Cherry?: typeof Cherry;
+    Cherry?: typeof Cherry | typeof CherryStream;
+
+    /**
+     * Cherry Markdown 引擎构造函数。
+     *
+     * 仅包含核心引擎，不包含编辑器 UI。适用于：
+     * - 服务端渲染（SSR）
+     * - 纯文本转换场景
+     * - 无 UI 的解析需求
+     *
+     * @example
+     * ```ts
+     * const engine = new window.CherryEngine({
+     *   engine: { global: { urlProcessor: (url) => url } }
+     * });
+     * const html = engine.makeHtml(markdownText);
+     * ```
+     */
+    CherryEngine?: typeof CherryEngine;
 
     /**
      * Mermaid 代码块插件（UMD 构建产物自动挂载）

--- a/packages/cherry-markdown/types/global.d.ts
+++ b/packages/cherry-markdown/types/global.d.ts
@@ -1,18 +1,71 @@
 import Mermaid from 'mermaid';
-import katex from 'katex';
+import type * as EChartsType from 'echarts';
+import type { KatexOptions } from 'katex';
 
 // for IE
 export {};
+
+/** MathJax 运行时核心 API（仅声明 CherryMarkdown 实际使用的部分） */
+interface MathJaxRuntime {
+  /** 重置 tex 计数器 */
+  texReset?(): void;
+  /** 将 tex 源码转为 MathML Promise */
+  tex2mmlPromise?(tex: string, opts?: { display: boolean }): Promise<string>;
+  startup?: {
+    /** CSS 选择器数组，指定哪些元素需要 typeset */
+    elements?: string[];
+    /** 是否在页面加载时自动排版 */
+    typeset?: boolean;
+    [key: string]: unknown;
+  };
+  tex?: Record<string, unknown>;
+  options?: Record<string, unknown>;
+  loader?: { load?: string[] };
+  [key: string]: unknown;
+}
+
+/** katex 运行时 API（仅声明 CherryMarkdown 实际使用的部分） */
+interface KatexRuntime {
+  renderToString(tex: string, options?: KatexOptions): string;
+  render?(tex: string, element: HTMLElement, options?: KatexOptions): void;
+  [key: string]: unknown;
+}
 
 declare global {
   const BUILD_ENV: string;
   interface Window {
     // for IE
     clipboardData: ClipboardEvent['clipboardData'];
+
+    /**
+     * mermaid 实例（v9+ 均通过顶层对象访问）
+     * 用户可通过 CDN <script> 加载后挂载到 window，或通过 CherryMarkdown externals 注入
+     */
     mermaid?: typeof Mermaid;
-    mermaidAPI?: typeof Mermaid['mermaidAPI'];
-    echarts?: echarts.ECharts;
-    MathJax?: any;
-    katex?: katex;
+
+    /**
+     * @deprecated v10+ 已废弃。v9 及以下版本的独立 mermaidAPI 子对象。
+     * v10+ 所有功能已合并到顶层 mermaid 对象。
+     * 保留此声明仅为兼容旧版本使用者传入的 mermaidAPI 参数。
+     */
+    mermaidAPI?: {
+      initialize(config: Record<string, unknown>): void;
+      render(
+        id: string,
+        code: string,
+        callback?: (svg: string) => void,
+        container?: HTMLElement,
+      ): unknown | Promise<{ svg: string }>;
+      [key: string]: unknown;
+    };
+
+    /** echarts 实例（用户需自行通过 CDN 或 script 标签注入） */
+    echarts?: EChartsType.ECharts;
+
+    /** MathJax 实例（用户需自行通过 CDN 或 script 标签注入） */
+    MathJax?: MathJaxRuntime;
+
+    /** katex 实例（用户需自行通过 CDN 或 script 标签注入） */
+    katex?: KatexRuntime;
   }
 }

--- a/packages/cherry-markdown/types/global.d.ts
+++ b/packages/cherry-markdown/types/global.d.ts
@@ -1,71 +1,71 @@
-import Mermaid from 'mermaid';
-import type * as EChartsType from 'echarts';
-import type { KatexOptions } from 'katex';
+/**
+ * 全局类型声明（随 npm 发布给用户）
+ *
+ * 为通过 `<script>` 标签引入 cherry-markdown 的用户
+ * 提供 `window` 上挂载对象的类型支持。
+ *
+ * @example
+ * 在 tsconfig.json 中引入：
+ * ```json
+ * {
+ *   "compilerOptions": {
+ *     "types": ["cherry-markdown/types/global"]
+ *   }
+ * }
+ * ```
+ *
+ * 或在任意 .d.ts 文件中：
+ * ```ts
+ * /// <reference types="cherry-markdown/types/global" />
+ * ```
+ */
 
-// for IE
+import type Cherry from '../dist/types/Cherry';
+import type MermaidCodeEngine from '../dist/types/addons/cherry-code-block-mermaid-plugin';
+import type PlantUMLCodeEngine from '../dist/types/addons/cherry-code-block-plantuml-plugin';
+
 export {};
 
-/** MathJax 运行时核心 API（仅声明 CherryMarkdown 实际使用的部分） */
-interface MathJaxRuntime {
-  /** 重置 tex 计数器 */
-  texReset?(): void;
-  /** 将 tex 源码转为 MathML Promise */
-  tex2mmlPromise?(tex: string, opts?: { display: boolean }): Promise<string>;
-  startup?: {
-    /** CSS 选择器数组，指定哪些元素需要 typeset */
-    elements?: string[];
-    /** 是否在页面加载时自动排版 */
-    typeset?: boolean;
-    [key: string]: unknown;
-  };
-  tex?: Record<string, unknown>;
-  options?: Record<string, unknown>;
-  loader?: { load?: string[] };
-  [key: string]: unknown;
-}
-
-/** katex 运行时 API（仅声明 CherryMarkdown 实际使用的部分） */
-interface KatexRuntime {
-  renderToString(tex: string, options?: KatexOptions): string;
-  render?(tex: string, element: HTMLElement, options?: KatexOptions): void;
-  [key: string]: unknown;
-}
-
 declare global {
-  const BUILD_ENV: string;
   interface Window {
-    // for IE
-    clipboardData: ClipboardEvent['clipboardData'];
+    /**
+     * Cherry Markdown 编辑器构造函数。
+     *
+     * 根据引入的构建产物不同，类型有所区别：
+     * - 完整版（cherry-markdown.js / cherry-markdown.core.js）→ `Cherry`
+     * - 流式版（cherry-markdown.stream.js）→ `CherryStream`
+     *
+     * 默认类型为完整版 `Cherry`，如需精确类型可自行 narrowing。
+     *
+     * @example
+     * ```ts
+     * const cherry = new window.Cherry({ id: 'markdown' });
+     * ```
+     */
+    Cherry?: typeof Cherry;
 
     /**
-     * mermaid 实例（v9+ 均通过顶层对象访问）
-     * 用户可通过 CDN <script> 加载后挂载到 window，或通过 CherryMarkdown externals 注入
+     * Mermaid 代码块插件（UMD 构建产物自动挂载）
+     *
+     * @example
+     * ```ts
+     * Cherry.usePlugin(window.CherryCodeBlockMermaidPlugin, {
+     *   mermaid: window.mermaid,
+     * });
+     * ```
      */
-    mermaid?: typeof Mermaid;
+    CherryCodeBlockMermaidPlugin?: typeof MermaidCodeEngine;
 
     /**
-     * @deprecated v10+ 已废弃。v9 及以下版本的独立 mermaidAPI 子对象。
-     * v10+ 所有功能已合并到顶层 mermaid 对象。
-     * 保留此声明仅为兼容旧版本使用者传入的 mermaidAPI 参数。
+     * PlantUML 代码块插件（UMD 构建产物自动挂载）
+     *
+     * @example
+     * ```ts
+     * Cherry.usePlugin(window.CherryCodeBlockPlantumlPlugin, {
+     *   baseUrl: 'http://www.plantuml.com/plantuml',
+     * });
+     * ```
      */
-    mermaidAPI?: {
-      initialize(config: Record<string, unknown>): void;
-      render(
-        id: string,
-        code: string,
-        callback?: (svg: string) => void,
-        container?: HTMLElement,
-      ): unknown | Promise<{ svg: string }>;
-      [key: string]: unknown;
-    };
-
-    /** echarts 实例（用户需自行通过 CDN 或 script 标签注入） */
-    echarts?: EChartsType.ECharts;
-
-    /** MathJax 实例（用户需自行通过 CDN 或 script 标签注入） */
-    MathJax?: MathJaxRuntime;
-
-    /** katex 实例（用户需自行通过 CDN 或 script 标签注入） */
-    katex?: KatexRuntime;
+    CherryCodeBlockPlantumlPlugin?: typeof PlantUMLCodeEngine;
   }
 }


### PR DESCRIPTION
## 背景

### 1. SSR 安全隐患
项目中大量直接通过 `window.xxx` 访问外部依赖（echarts、mermaid、katex、MathJax）和做环境判断，在非浏览器环境下会抛出异常。

### 2. 全局类型声明对用户不友好
原来的 `global.d.ts` 直接 `import Mermaid from 'mermaid'` 和 `import katex from 'katex'`，
但 mermaid/katex/echarts/MathJax 对用户来说都是可选依赖——用户完全可能不安装它们。
这导致用户引入 `global.d.ts` 时，TypeScript 会报"找不到模块"错误。

而且该文件只声明了 `window.mermaid`/`window.katex` 等第三方对象，
缺少 cherry-markdown 自身挂载的 `window.Cherry`、`window.CherryEngine` 等核心类型。

## 改动

### 1. 统一环境检测与外部依赖获取
- 新增 `getExternal()` 工具函数，内置 `isBrowser` 守卫，统一收口外部依赖获取
- 各模块中 `window.xxx` 直接访问统一替换为 `isBrowser()` + `getExternal()`

### 2. 拆分类型声明职责
- **`global.d.ts`（用户用）**：移除对 mermaid/katex 等第三方包的 import，改为只声明 cherry-markdown 自身挂载的 `window.Cherry`、`window.CherryEngine`、`window.CherryCodeBlockMermaidPlugin` 等，用户不再被迫安装不需要的可选依赖
- **`env.d.ts`（开发用，新增）**：承接原来的第三方依赖类型（mermaid、katex、echarts、MathJax），仅开发编译时使用，不随 npm 发布
- **`package.json`**：`files` 排除 `env.d.ts`

## 无功能变更，不影响运行时行为。
