### PR TITLE
fix: 优化mermaid图的预览区交互效果

### DIFF
--- a/.changeset/giant-buses-search.md
+++ b/.changeset/giant-buses-search.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 优化mermaid图的预览区交互效果

--- a/examples/assets/scripts/index-demo.js
+++ b/examples/assets/scripts/index-demo.js
@@ -226,6 +226,10 @@ const basicConfig = {
         wrapperRender: (lang, code, html) => {
           return `<div class="custom-codeblock-wrapper language-${lang}" data-tips="可以自定义代码块外层容器">${html}</div>`;
         },
+        mermaid: {
+          svg2img: false, // 是否将mermaid生成的画图变成img格式
+          showSourceToolbar: true, // 是否显示mermaid源码/预览切换工具栏
+        },
         customBtns: [
           {
             html: '自定义按钮1',

--- a/packages/cherry-markdown/src/core/hooks/CodeBlock.js
+++ b/packages/cherry-markdown/src/core/hooks/CodeBlock.js
@@ -308,7 +308,7 @@ export default class CodeBlock extends ParagraphBase {
       >
       ${this.customWrapperRender(oldLang, cacheCode, codeHtml)}
       `;
-    if (needUnExpand) {
+    if (needUnExpand && $lang !== 'mermaid') {
       cacheCode += `<div class="cherry-mask-code-block">
         <div class="expand-btn ">
           <i class="ch-icon ch-icon-expand"></i>

--- a/packages/cherry-markdown/src/toolbars/PreviewerBubble.js
+++ b/packages/cherry-markdown/src/toolbars/PreviewerBubble.js
@@ -1009,6 +1009,10 @@ export default class PreviewerBubble {
     if (!this.$isEnableBubbleAndEditorShow()) {
       return;
     }
+    const sourceMode = figureElement.querySelector('.cherry-mermaid-source-toolbar-panel.active[data-mode="source"]');
+    if (sourceMode) {
+      return;
+    }
     this.$createPreviewerBubbles('click', 'img-handler');
 
     this.mermaidFigure = figureElement;
@@ -1196,6 +1200,8 @@ export default class PreviewerBubble {
     const panels = figure.querySelectorAll('.cherry-mermaid-source-toolbar-panel');
 
     if (!slider || !tabs || !panels.length) return;
+
+    this.$removeAllPreviewerBubbles();
 
     // 切换 tab active 状态
     tabs.forEach((tab) => tab.classList.remove('active'));

--- a/packages/cherry-markdown/src/utils/codeBlockContentHandler.js
+++ b/packages/cherry-markdown/src/utils/codeBlockContentHandler.js
@@ -182,7 +182,14 @@ export default class CodeBlockHandler {
    * 展示代码块区域的按钮
    */
   $showBtn(isEnableBubbleAndEditorShow) {
-    const { changeLang, editCode, copyCode, lang, expandCode } = this.target.dataset;
+    let { changeLang, editCode, copyCode, lang, expandCode } = this.target.dataset;
+    if (this.target.closest('.cherry-mermaid-source-toolbar-panel')) {
+      changeLang = 'false';
+      editCode = 'false';
+      expandCode = 'false';
+      copyCode = copyCode;
+      lang = lang;
+    }
     this.container.innerHTML = '';
     if (changeLang === 'true' && isEnableBubbleAndEditorShow) {
       // 添加删除btn


### PR DESCRIPTION
- 默认demo配置为：mermaid图增加切换代码配置
- mermaid图切换为源码时，自动去掉修改尺寸的交互
- 在mermaid 源码状态在，不响应修改尺寸的交互