### PR TITLE
fix: 将 mermaid 日志级别调整为 `fatal`

### DIFF
--- a/.changeset/fix-mermaid-log-level.md
+++ b/.changeset/fix-mermaid-log-level.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 将 mermaid 日志级(`logLevel`)别调整为 `fatal`(依然是 `5`)

--- a/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
+++ b/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
@@ -48,7 +48,7 @@ const DEFAULT_OPTIONS = {
   fontFamily: 'sans-serif',
   themeCSS: '.label foreignObject { font-size: 90%; overflow: visible; } .label { font-family: sans-serif; }',
   startOnLoad: false,
-  logLevel: 'error',
+  logLevel: 'fatal',
   // fontFamily: 'Arial, monospace'
 };
 


### PR DESCRIPTION
修复 #1671 改动的日志级别导致流式渲染过程中的报错