### PR TITLE
fix: correct off-by-one error in duplicate header ID generation

### DIFF
--- a/packages/cherry-markdown/src/core/hooks/Header.js
+++ b/packages/cherry-markdown/src/core/hooks/Header.js
@@ -83,7 +83,7 @@ export default class Header extends ParagraphBase {
     const idIndex = this.headerIDCache.indexOf(newId);
     if (idIndex !== -1) {
       this.headerIDCounter[idIndex] += 1;
-      newId += `-${this.headerIDCounter[idIndex] + 1}`;
+      newId += `-${this.headerIDCounter[idIndex]}`;
     } else {
       const newIndex = this.headerIDCache.push(newId);
       this.headerIDCounter[newIndex - 1] = 1;


### PR DESCRIPTION
## Summary
- Fixed off-by-one error in `generateIDNoDup()` in `packages/cherry-markdown/src/core/hooks/Header.js`
- When duplicate headers exist, the generated IDs were skipping numbers (e.g., `"test"`, `"test-3"`, `"test-4"` instead of `"test"`, `"test-2"`, `"test-3"`)

## Root Cause
In `Header.js` line 86, the counter was incremented (`+= 1`) and then `+1` was added again when building the ID string, causing the first duplicate to start at suffix `-3` instead of `-2`:
```javascript
// Before (buggy):
this.headerIDCounter[idIndex] += 1;
newId += `-${this.headerIDCounter[idIndex] + 1}`;  // double increment

// After (fixed):
this.headerIDCounter[idIndex] += 1;
newId += `-${this.headerIDCounter[idIndex]}`;  // single increment
```

## Test plan
- [x] Existing tests in `test/core/HookCenter.spec.ts` and `test/core/SyntaxBase.spec.ts` pass
- [x] Verified the fix produces correct IDs: `"test"`, `"test-2"`, `"test-3"` for duplicate headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)