### PR TITLE
fix: prevent undefined image src when beforeImageMounted is not configured

### DIFF
--- a/packages/cherry-markdown/src/core/hooks/Image.js
+++ b/packages/cherry-markdown/src/core/hooks/Image.js
@@ -84,7 +84,7 @@ export default class Image extends SyntaxBase {
       }
       attrs = title && title.trim() !== '' ? ` title="${$e(title.replace(/["']/g, ''))}"` : '';
       let srcProp = 'src';
-      let srcValue;
+      let srcValue = link;
       const cherryOptions = this.$engine.$cherry.options;
       if (cherryOptions.callback && cherryOptions.callback.beforeImageMounted) {
         const imgAttrs = cherryOptions.callback.beforeImageMounted(srcProp, link);


### PR DESCRIPTION
## Summary
- Fixed a bug in `Image.js` `toHtml()` where `srcValue` could be `undefined` when the `beforeImageMounted` callback is not configured
- This caused `encodeURI(undefined)` to produce the literal string `"undefined"` as the image `src` attribute

## Root Cause
In `packages/cherry-markdown/src/core/hooks/Image.js` line 87, `srcValue` was declared with `let` but not initialized:
```javascript
let srcValue;  // undefined by default
const cherryOptions = this.$engine.$cherry.options;
if (cherryOptions.callback && cherryOptions.callback.beforeImageMounted) {
  // srcValue is only assigned here
  srcValue = imgAttrs.src || link;
}
// If callback is not configured, srcValue is still undefined
encodeURIOnce(this.$engine.urlProcessor(srcValue, 'image'))
```

The fix initializes `srcValue` with `link` as the default value.

## Test plan
- [x] Existing tests in `test/core/hooks/` pass
- [x] Verified images render correctly when `beforeImageMounted` is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)