### PR TITLE
fix: prevent last code line loss when code block has no trailing newline

### DIFF
--- a/packages/cherry-markdown/src/core/hooks/CodeBlock.js
+++ b/packages/cherry-markdown/src/core/hooks/CodeBlock.js
@@ -174,7 +174,10 @@ export default class CodeBlock extends ParagraphBase {
   renderLineNumber(code) {
     if (!this.lineNumber) return code;
     let codeLines = code.split('\n');
-    codeLines.pop(); // 末尾回车不增加行号
+    // 只有当最后一行为空时（即代码以换行符结尾）才移除，避免丢失实际代码行
+    if (codeLines.length > 0 && codeLines[codeLines.length - 1] === '') {
+      codeLines.pop();
+    }
     codeLines = this.fillTag(codeLines);
     return `<span class="code-line">${codeLines.join('</span>\n<span class="code-line">')}</span>`;
   }


### PR DESCRIPTION
## Summary
- Fixed a bug in `CodeBlock.js` `renderLineNumber()` where the last line of code could be lost when the code doesn't end with a trailing newline

## Root Cause
In `packages/cherry-markdown/src/core/hooks/CodeBlock.js` line 177, `codeLines.pop()` was called unconditionally after splitting code by `\n`:
```javascript
let codeLines = code.split('\n');
codeLines.pop(); // Always removes last element
```

When code ends with a newline (e.g., `"line1\nline2\n"`), `split('\n')` produces `["line1", "line2", ""]`, and `pop()` correctly removes the empty trailing element.

However, when code does NOT end with a newline (e.g., `"line1\nline2"`), `split('\n')` produces `["line1", "line2"]`, and `pop()` incorrectly removes `"line2"` — the last actual line of code. This causes the last line to not have a line number and to disappear from the rendered output.

The fix only removes the last element when it's an empty string (indicating a trailing newline).

## Test plan
- [x] Existing tests in `test/core/` pass
- [x] Code blocks with trailing newlines render correctly
- [x] Code blocks without trailing newlines no longer lose their last line

🤖 Generated with [Claude Code](https://claude.com/claude-code)