### PR TITLE
fix: use parsed numeric code point for hex entity validation in sanitize.js

### DIFF
--- a/packages/cherry-markdown/src/utils/sanitize.js
+++ b/packages/cherry-markdown/src/utils/sanitize.js
@@ -365,7 +365,7 @@ export function escapeHTMLEntitiesWithoutSemicolon(content) {
       match.indexOf(';') === -1 ||
       hexCodePoint.length > 6 ||
       // Object.keys(htmlEntitiesMap).indexOf(decimalCodePoint) === -1
-      !isValidStringCodePoint(hexCode)
+      !isValidStringCodePoint(decimalCodePoint)
     ) {
       return match.replace(/&/g, '&amp;');
     }


### PR DESCRIPTION
## Summary
- Fixed incorrect variable passed to `isValidStringCodePoint()` in hex entity validation in `sanitize.js`

## Root Cause
In `packages/cherry-markdown/src/utils/sanitize.js` line 368, the `escapeHTMLEntitiesWithoutSemicolon` function was passing `hexCode` (a string like `"0x41"`) to `isValidStringCodePoint()` instead of `decimalCodePoint` (the already-parsed numeric value `65`):

```javascript
const hexCode = `0x${hexCodePoint}`;
const decimalCodePoint = parseInt(hexCode, 16);
// ...
!isValidStringCodePoint(hexCode)  // Wrong: passes string "0x41"
```

`isValidStringCodePoint()` calls `String.fromCodePoint()`, which expects a number. While JavaScript's type coercion happens to convert `"0x41"` to `65` in most cases, this is semantically incorrect and inconsistent with the decimal entity validation on line 347, which correctly passes the string from the regex capture group.

The fix passes `decimalCodePoint` (the numeric value) instead, which is more correct and consistent.

## Test plan
- [x] Existing tests in `test/core/` and `test/utils/` pass
- [x] Hex entity validation works correctly for valid and invalid code points

🤖 Generated with [Claude Code](https://claude.com/claude-code)