### PR TITLE
fix(previewer): 修复 mermaid 尺寸拖拽后工具栏漂移

### DIFF
--- a/.changeset/mermaid-toolbar-drift.md
+++ b/.changeset/mermaid-toolbar-drift.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 修复 mermaid 图表尺寸拖拽后工具栏漂移

--- a/packages/cherry-markdown/src/toolbars/PreviewerBubble.js
+++ b/packages/cherry-markdown/src/toolbars/PreviewerBubble.js
@@ -1092,7 +1092,10 @@ export default class PreviewerBubble {
     const imgSizeDiv = document.createElement('div');
     imgSizeDiv.className = 'cherry-previewer-img-size-handler';
     this.bubble.click.appendChild(imgSizeDiv);
-    imgSizeHandler.showBubble(figureElement, imgSizeDiv, this.previewerDom, { isMermaid: true });
+    imgSizeHandler.showBubble(figureElement, imgSizeDiv, this.previewerDom, {
+      isMermaid: true,
+      targetIndex: this.mermaidIndex,
+    });
     imgSizeHandler.bindChange(this.changeMermaidSize.bind(this));
 
     // 添加对齐工具面板（仅对齐按钮，不含装饰按钮）
@@ -1105,7 +1108,7 @@ export default class PreviewerBubble {
       this.previewerDom,
       event,
       this.previewer.$cherry.getLocales(),
-      { isMermaid: true },
+      { isMermaid: true, targetIndex: this.mermaidIndex },
     );
     imgToolHandler.bindChange(this.changeMermaidStyle.bind(this));
 
@@ -1132,6 +1135,7 @@ export default class PreviewerBubble {
     if (mermaidIndex < 0) {
       return false;
     }
+    this.mermaidIndex = mermaidIndex;
 
     const rawContent = this.editor.editor.view.state.doc.toString();
     // 在编辑器原始内容中按顺序找到所有 mermaid 代码块

--- a/packages/cherry-markdown/src/utils/imgSizeHandler.js
+++ b/packages/cherry-markdown/src/utils/imgSizeHandler.js
@@ -94,6 +94,7 @@ const imgSizeHandler = {
     }
     this.img = img;
     this.isMermaid = options.isMermaid || false;
+    this.targetIndex = Number.isInteger(options.targetIndex) ? options.targetIndex : -1;
     this.previewerDom = previewerDom;
     this.container = container;
     this.buts = this.initBubbleButtons();
@@ -121,6 +122,7 @@ const imgSizeHandler = {
     if (this.$isResizing()) {
       return;
     }
+    this.refreshTarget();
     // 预览区更新后图片位置可能变化（如对齐方式改变），需要更新选择框位置
     // 图片有 CSS transition (all 0.1s)，需等待过渡动画结束后再获取最终位置
     this.img.addEventListener(
@@ -135,6 +137,13 @@ const imgSizeHandler = {
       this._fallbackTimer = null;
       this.updatePosition();
     }, 120);
+  },
+  refreshTarget() {
+    if (!this.isMermaid || this.targetIndex < 0 || !this.previewerDom) {
+      return;
+    }
+    const figures = this.previewerDom.querySelectorAll('figure[data-type="mermaid"]');
+    this.img = figures[this.targetIndex] || this.img;
   },
   drawBubbleButs() {
     if (this.butsLayout) {
@@ -315,7 +324,9 @@ const imgSizeHandler = {
       this.img.style.width = `${this.buts.style.width}px`;
       this.img.style.height = `${this.buts.style.height}px`;
     }
-    this.change();
+    if (!this.isMermaid) {
+      this.change();
+    }
   },
   change() {
     this.emitChange(this.img, { width: this.buts.style.width, height: this.buts.style.height });
@@ -351,6 +362,7 @@ const imgSizeHandler = {
     if (!this.img || !this.butsLayout || !this.previewerDom || this.$isResizing()) {
       return;
     }
+    this.refreshTarget();
     // 重新计算图片位置
     const newPosition = this.getImgPosition();
     this.buts.position = newPosition;

--- a/packages/cherry-markdown/src/utils/imgToolHandler.js
+++ b/packages/cherry-markdown/src/utils/imgToolHandler.js
@@ -37,6 +37,7 @@ const imgToolHandler = {
   showBubble(img, container, previewerDom, event, locale, options = {}) {
     this.img = img;
     this.isMermaid = options.isMermaid || false;
+    this.targetIndex = Number.isInteger(options.targetIndex) ? options.targetIndex : -1;
 
     this.previewerDom = previewerDom;
     this.container = container;
@@ -189,6 +190,7 @@ const imgToolHandler = {
     }
   },
   previewUpdate(callback) {
+    this.refreshTarget();
     // 预览区更新后图片位置可能变化（如对齐方式改变），需要更新工具栏位置
     // 图片有 CSS transition (all 0.1s)，需等待过渡动画结束后再获取最终位置
     this.img.addEventListener('transitionend', () => this.updatePosition(), { once: true });
@@ -197,6 +199,13 @@ const imgToolHandler = {
       this._fallbackTimer = null;
       this.updatePosition();
     }, 120);
+  },
+  refreshTarget() {
+    if (!this.isMermaid || this.targetIndex < 0 || !this.previewerDom) {
+      return;
+    }
+    const figures = this.previewerDom.querySelectorAll('figure[data-type="mermaid"]');
+    this.img = figures[this.targetIndex] || this.img;
   },
   remove() {
     this.butsLayout = false;
@@ -212,6 +221,7 @@ const imgToolHandler = {
     if (!this.img || !this.container || !this.previewerDom) {
       return;
     }
+    this.refreshTarget();
     const imgPosition = this.getImgPosition();
     const toolbarWidth = this.container.offsetWidth;
     const toolbarHeight = this.container.offsetHeight;


### PR DESCRIPTION
### 问题

Fixes #1740

在预览区点击 mermaid 图表后，拖拽调整图表尺寸，图表操作工具栏会漂移到错误位置，部分场景会漂到左上角。

### 原因

mermaid 图表尺寸拖拽过程中会更新 markdown 内容并触发预览区重渲染。重渲染后原来的 `figure[data-type="mermaid"]` DOM 被替换，但尺寸框和工具栏 handler 仍然持有旧 DOM 引用，后续定位计算基于旧元素，导致工具栏位置漂移。

### 修改

- mermaid 尺寸拖拽过程中仅更新当前图表 DOM 的可视尺寸，不在 `mousemove` 阶段反复写回 markdown
- 在拖拽结束时写回最终尺寸
- 为 mermaid 尺寸框和工具栏记录当前图表索引
- 预览区更新后重新绑定新的 mermaid figure DOM，避免继续使用旧 DOM 计算位置

### 验证

- 本地打开 `http://localhost:5173/mermaid.html`
- 点击预览区 mermaid 图表
- 拖拽调整图表尺寸
- 工具栏不再漂移到右上角，位置跟随图表保持正常

### 截图

修复前：

<img width="2124" height="712" alt="592942203-02998340-c5c7-41dd-b77b-a05658e63405" src="https://github.com/user-attachments/assets/270524da-1860-4099-8035-06506f4e6e37" />

修复后：

<img width="770" height="389" alt="img_v3_0211p_66fc9b49-b7fb-46c2-a62c-5c03d213f69g" src="https://github.com/user-attachments/assets/68371c67-6a18-48c1-8de5-8ac7dca9a3aa" />
