### PR TITLE
refactor(styles): migrate`Sass` to `@use` and `rollup-plugin-sass` modern API

### DIFF
--- a/.changeset/rss1102-sass-modern-api.md
+++ b/.changeset/rss1102-sass-modern-api.md
@@ -1,0 +1,8 @@
+---
+'cherry-markdown': patch
+---
+
+内部优化样式构建：Sass 迁移至模块系统（`@use` / `@forward`），并使用 `rollup-plugin-sass` 现代编译 API，消除构建时的弃用警告。
+
+对使用者无破坏性变更：`import 'cherry-markdown/dist/cherry-markdown.css'` 与原有 API、主题类名保持不变。
+⚠️ 若你通过自定义 CSS 覆盖 `.cherry-bubble` 相关样式，建议在升级后确认预览区图片工具条外观是否符合预期。

--- a/packages/cherry-markdown/build/rollup.styles.config.js
+++ b/packages/cherry-markdown/build/rollup.styles.config.js
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import scss from 'rollup-plugin-scss';
-import * as dartSass from 'sass';
-// baseConfig not used in styles config
+import sass from 'rollup-plugin-sass';
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
@@ -37,15 +35,15 @@ const createStyleConfigs = ({ input, cssBaseName, outputBaseName, watch }) => {
   const configs = [
     {
       input,
+      treeshake: false,
       output: {
         file: `dist/${outputBaseName}.styles.js`,
       },
       plugins: [
-        scss({
-          fileName: `${cssBaseName}.css`,
-          failOnError: true,
-          sass: dartSass,
-          ...(watch ? { watch } : {}),
+        sass({
+          api: 'modern',
+          output: `dist/${cssBaseName}.css`,
+          options: { style: 'expanded' },
         }),
         createCleanupPlugin(),
       ],
@@ -55,15 +53,15 @@ const createStyleConfigs = ({ input, cssBaseName, outputBaseName, watch }) => {
   if (IS_PRODUCTION) {
     configs.push({
       input,
+      treeshake: false,
       output: {
         file: `dist/${outputBaseName}.styles.min.js`,
       },
       plugins: [
-        scss({
-          fileName: `${cssBaseName}.min.css`,
-          failOnError: true,
-          sass: dartSass,
-          outputStyle: 'compressed',
+        sass({
+          api: 'modern',
+          output: `dist/${cssBaseName}.min.css`,
+          options: { style: 'compressed' },
         }),
         createCleanupPlugin(),
       ],

--- a/packages/cherry-markdown/package.json
+++ b/packages/cherry-markdown/package.json
@@ -95,9 +95,9 @@
     "rimraf": "^3.0.2",
     "rollup": "4.52.3",
     "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-scss": "^4.0.1",
+    "rollup-plugin-sass": "^1.15.3",
     "rollup-plugin-typescript2": "^0.36.0",
-    "sass": "^1.52.3",
+    "sass": "^1.99.0",
     "serve": "^14.2.0",
     "virtual-dom": "^2.1.1"
   },

--- a/packages/cherry-markdown/src/sass/cherry.scss
+++ b/packages/cherry-markdown/src/sass/cherry.scss
@@ -1,13 +1,15 @@
-@import './variables/index.scss';
-@import './base.scss';
-@import './ch-icon.scss';
-@import './markdown.scss';
-@import './previewer.scss';
-@import './print.scss';
-@import './bubble_formula.scss';
-@import './formula_utils_bubble.scss';
-@import './components/shortcut_key_config.scss';
-@import './codemirror-v6-fixes';
+@use 'sass:meta';
+
+@use './variables/index';
+@use './base';
+@use './ch-icon';
+@use './markdown';
+@use './previewer';
+@use './print';
+@use './bubble_formula';
+@use './formula_utils_bubble';
+@use './components/shortcut_key_config';
+@use './codemirror-v6-fixes';
 
 @mixin cherryFont {
   font-family: var(--font-family-sans);
@@ -634,8 +636,6 @@
     }
   }
 }
-
-@import './components/bubble';
 
 .cherry-floatmenu {
   z-index: 4;
@@ -1769,11 +1769,11 @@
 }
 
 /** 引入自带的主题 */
-@import './themes/default.scss';
-@import './themes/dark.scss';
-@import './themes/abyss.scss';
-@import './themes/green.scss';
-@import './themes/red.scss';
-@import './themes/gray.scss';
-@import './themes/violet.scss';
-@import './themes/blue.scss';
+@include meta.load-css('./themes/default');
+@include meta.load-css('./themes/dark');
+@include meta.load-css('./themes/abyss');
+@include meta.load-css('./themes/green');
+@include meta.load-css('./themes/red');
+@include meta.load-css('./themes/gray');
+@include meta.load-css('./themes/violet');
+@include meta.load-css('./themes/blue');

--- a/packages/cherry-markdown/src/sass/components/bubble.scss
+++ b/packages/cherry-markdown/src/sass/components/bubble.scss
@@ -1,4 +1,16 @@
-.cherry-bubble {
+// 气泡浮层的「基础盒模型」样式（定位、边框、背景、阴影等）。
+//
+// 说明：
+// - 这是 Sass @mixin，编译后不会出现 .cherry-bubble-base 类名，DOM 仍使用 .cherry-bubble。
+// - 后缀 -base 表示可被多处 @include 的公共片段，不是额外的 CSS 选择器。
+// - 使用 @mixin 而非 @extend：Sass 模块体系下 @extend 不能跨文件引用（previewer 与 bubble 分属不同模块）。
+// - 与 @extend 的差异：@include 会把样式复制到每个选择器；覆盖 .cherry-bubble 不会自动作用于
+//   .cherry-previewer-img-tool-handler，需分别覆盖或写共同父选择器。
+//
+// 使用处：
+// - 本文件 .cherry-bubble
+// - previewer.scss → .cherry .cherry-previewer-img-tool-handler（@include bubble.cherry-bubble-base）
+@mixin cherry-bubble-base {
   position: absolute;
 
   display: flex;
@@ -17,6 +29,11 @@
   border-radius: var(--bubble-radius);
   z-index: var(--bubble-z-index);
   padding: var(--spacing-xs);
+}
+
+// 编辑器/预览区通用气泡容器；基础样式来自 cherry-bubble-base，下方为气泡专有结构（箭头等）
+.cherry-bubble {
+  @include cherry-bubble-base;
 
   &.cherry-bubble--centered {
     left: 50%;

--- a/packages/cherry-markdown/src/sass/index.scss
+++ b/packages/cherry-markdown/src/sass/index.scss
@@ -2,4 +2,4 @@
 
 // CodeMirror 6 不需要单独引入样式文件,样式已集成在 @codemirror/view 中
 
-@import './cherry.scss';
+@use './cherry';

--- a/packages/cherry-markdown/src/sass/markdown.scss
+++ b/packages/cherry-markdown/src/sass/markdown.scss
@@ -1,3 +1,5 @@
+@use 'sass:meta';
+
 .cherry-markdown {
   word-break: break-all;
   color: var(--md-paragraph-color);
@@ -691,7 +693,7 @@
 }
 
 div[data-type='codeBlock'] {
-  @import 'prism/tomorrow-night';
+  @include meta.load-css('prism/tomorrow-night');
 
   div[data-code-wrap='wrap'] & code[class*=language-]{
     white-space: pre-wrap;
@@ -699,43 +701,43 @@ div[data-type='codeBlock'] {
   }
 
   [data-code-block-theme='default'] & {
-    @import 'prism/default';
+    @include meta.load-css('prism/default');
   }
 
   [data-code-block-theme='dark'] & {
-    @import 'prism/dark';
+    @include meta.load-css('prism/dark');
   }
 
   [data-code-block-theme='one-dark'] & {
-    @import 'prism/one-dark';
+    @include meta.load-css('prism/one-dark');
   }
 
   [data-code-block-theme='one-light'] & {
-    @import 'prism/one-light';
+    @include meta.load-css('prism/one-light');
   }
 
   [data-code-block-theme='vs-dark'] & {
-    @import 'prism/vs-dark';
+    @include meta.load-css('prism/vs-dark');
   }
 
   [data-code-block-theme='vs-light'] & {
-    @import 'prism/vs-light';
+    @include meta.load-css('prism/vs-light');
   }
 
   [data-code-block-theme='okaidia'] & {
-    @import 'prism/okaidia';
+    @include meta.load-css('prism/okaidia');
   }
 
   [data-code-block-theme='twilight'] & {
-    @import 'prism/twilight';
+    @include meta.load-css('prism/twilight');
   }
 
   [data-code-block-theme='coy'] & {
-    @import 'prism/coy';
+    @include meta.load-css('prism/coy');
   }
 
   [data-code-block-theme='solarized-light'] & {
-    @import 'prism/solarized-light';
+    @include meta.load-css('prism/solarized-light');
   }
 }
 

--- a/packages/cherry-markdown/src/sass/markdown_pure.scss
+++ b/packages/cherry-markdown/src/sass/markdown_pure.scss
@@ -1,10 +1,13 @@
-@import './markdown.scss';
-/** 引入自带的主题 */
-@import './themes/default.scss';
-@import './themes/dark.scss';
-@import './themes/abyss.scss';
-@import './themes/green.scss';
-@import './themes/red.scss';
-@import './themes/gray.scss';
-@import './themes/violet.scss';
-@import './themes/blue.scss';
+@use 'sass:meta';
+
+@use './markdown';
+
+/** 引入自带的主题（保持与 cherry 一致的主题覆盖顺序） */
+@include meta.load-css('./themes/default');
+@include meta.load-css('./themes/dark');
+@include meta.load-css('./themes/abyss');
+@include meta.load-css('./themes/green');
+@include meta.load-css('./themes/red');
+@include meta.load-css('./themes/gray');
+@include meta.load-css('./themes/violet');
+@include meta.load-css('./themes/blue');

--- a/packages/cherry-markdown/src/sass/previewer.scss
+++ b/packages/cherry-markdown/src/sass/previewer.scss
@@ -1,3 +1,5 @@
+@use './components/bubble';
+
 .cherry {
   .doing-resize-img {
     -moz-user-select:none;
@@ -82,8 +84,9 @@
       cursor:e-resize;
     }
   }
+  // 复用 bubble 模块的基础盒模型；扩展样式见本选择器内，勿改用 @extend（跨模块不可用）
   .cherry-previewer-img-tool-handler {
-    @extend .cherry-bubble;
+    @include bubble.cherry-bubble-base;
     padding: var(--bubble-padding);
     display: flex;
     flex-direction: column;

--- a/packages/cherry-markdown/src/sass/variables/index.scss
+++ b/packages/cherry-markdown/src/sass/variables/index.scss
@@ -1,11 +1,6 @@
 // CSS 变量导出文件
 // 统一导入和导出所有 CSS 变量
 
-// 导入一级变量（基础效果变量）
-@import './base.scss';
-
-// 导入二级变量（语义化界面变量）
-@import './semantic.scss';
-
-// 导入 Open Color 颜色
-@import './open-color.scss';
+@use './base';
+@use './semantic';
+@use './open-color';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,15 +2400,7 @@
     smob "^1.0.0"
     terser "^5.17.4"
 
-"@rollup/pluginutils@^4.1.2":
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
-  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
-  dependencies:
-    estree-walker "^2.0.1"
-    picomatch "^2.2.2"
-
-"@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.1.0":
+"@rollup/pluginutils@^3 || ^4 || ^5", "@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.1.0":
   version "5.3.0"
   resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz#57ba1b0cbda8e7a3c597a4853c807b156e21a7b4"
   integrity sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==
@@ -2416,6 +2408,14 @@
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
+
+"@rollup/pluginutils@^4.1.2":
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
+  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
+  dependencies:
+    estree-walker "^2.0.1"
+    picomatch "^2.2.2"
 
 "@rollup/rollup-android-arm-eabi@4.52.3":
   version "4.52.3"
@@ -5111,11 +5111,6 @@ cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.5, 
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto-js@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
-  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 css-declaration-sorter@^6.3.1:
   version "6.4.1"
@@ -10385,7 +10380,7 @@ resolve-options@^2.0.0:
   dependencies:
     value-or-function "^4.0.0"
 
-resolve@^1.10.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.11:
+resolve@^1.10.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.11, resolve@^1.5.0:
   version "1.22.12"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
   integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
@@ -10466,12 +10461,14 @@ rollup-plugin-postcss@^4.0.2:
     safe-identifier "^0.4.2"
     style-inject "^0.3.0"
 
-rollup-plugin-scss@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-4.0.1.tgz#5677eff2754525cebc813a9b876ae7ec44d192b4"
-  integrity sha512-3W3+3OzR+shkDl3hJ1XTAuGkP4AfiLgIjie2GtcoZ9pHfRiNqeDbtCu1EUnkjZ98EPIM6nnMIXkKlc7Sx5bRvA==
+rollup-plugin-sass@^1.15.3:
+  version "1.15.3"
+  resolved "https://registry.npmjs.org/rollup-plugin-sass/-/rollup-plugin-sass-1.15.3.tgz#798667792f3b760aa771af313b119df25ff5f32e"
+  integrity sha512-HPRjdUR/Ymu/v/H9qaPytqBAAYVN/5Agmu9RH+PMpTS22lcAvz3FWzqjs1cUaWh5ln1VvtwIcNykBOQkWkpUig==
   dependencies:
-    rollup-pluginutils "^2.3.3"
+    "@rollup/pluginutils" "^3 || ^4 || ^5"
+    resolve "^1.5.0"
+    sass "^1.7.2"
 
 rollup-plugin-typescript2@^0.36.0:
   version "0.36.0"
@@ -10484,7 +10481,7 @@ rollup-plugin-typescript2@^0.36.0:
     semver "^7.5.4"
     tslib "^2.6.2"
 
-rollup-pluginutils@^2.3.3, rollup-pluginutils@^2.8.2:
+rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -10643,7 +10640,7 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@^1.52.3:
+sass@^1.7.2, sass@^1.99.0:
   version "1.99.0"
   resolved "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz#ff9d1594da4886249dfaafabbeea2dea2dc74b26"
   integrity sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==


### PR DESCRIPTION
Replace deprecated `@import` with @use/meta.load-css, switch style build from `rollup-plugin-scss` to `rollup-plugin-sass `with api modern, and extract bubble base styles as a mixin for cross-module reuse.