### PR TITLE
fix(vscodePlugin): 修复 F5 启动扩展的调试任务配置

### DIFF
--- a/packages/vscodePlugin/.vscode/launch.json
+++ b/packages/vscodePlugin/.vscode/launch.json
@@ -15,7 +15,7 @@
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],
-      "preLaunchTask": "yarn:watch"
+      "preLaunchTask": "build:extension"
     }
   ]
 }

--- a/packages/vscodePlugin/.vscode/tasks.json
+++ b/packages/vscodePlugin/.vscode/tasks.json
@@ -1,37 +1,35 @@
-// See https://go.microsoft.com/fwlink/?LinkId=733558
-// for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"label": "yarn:watch",
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": {
-				"owner": "rspack",
-				"fileLocation": ["relative", "${workspaceFolder}"],
-				"pattern": {
-					"regexp": "^(.*):(\\d+):(\\d+):\\s+(error|warning):\\s+(.*)$",
-					"file": 1,
-					"line": 2,
-					"column": 3,
-					"severity": 4,
-					"message": 5
-				},
-				"background": {
-					"activeOnStart": true,
-					"beginsPattern": "^\\s*Compiling",
-					"endsPattern": "^\\s*(Successfully|Failed)"
-				}
-			},
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build:cherry-markdown",
+      "type": "shell",
+      "command": "test -f ../cherry-markdown/dist/cherry-markdown.min.css && test -f ../cherry-markdown/dist/cherry-markdown.esm.js || yarn workspace cherry-markdown build",
+      "options": {
+        "cwd": "${workspaceFolder}/../.."
+      },
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared",
+        "focus": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "build:extension",
+      "type": "npm",
+      "script": "build",
+      "dependsOn": ["build:cherry-markdown"],
+      "dependsOrder": "sequence",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
 }


### PR DESCRIPTION
原 preLaunchTask "yarn:watch" 指向不存在的 watch 脚本，且 problemMatcher 缺少 beginsPattern 导致 VS Code 报错。

- launch.json: preLaunchTask 改为 build:extension
- tasks.json: 新建 build:cherry-markdown（按需构建核心库）与 build:extension（依赖前者并构建插件），去除有问题的后台 watch 任务

这样首次 F5 即可正确产出 dist/extension.js 并启动扩展开发宿主。