### PR TITLE
fix(ci): 修复 release dist zip 因相对路径错位未上传到 GitHub Release

### DIFF
--- a/.github/workflows/reusable-npm-release.yml
+++ b/.github/workflows/reusable-npm-release.yml
@@ -45,15 +45,13 @@ jobs:
       # =========================================================================
       - name: Package dist to zip
         if: inputs.core_version != ''
-        working-directory: ./packages/cherry-markdown
-        run: |
-          cd dist
-          zip -r ../../cherry-markdown-${{ inputs.core_version }}.zip .
-          cd ../..
+        working-directory: ./packages/cherry-markdown/dist
+        run: zip -r "$GITHUB_WORKSPACE/cherry-markdown-${{ inputs.core_version }}.zip" .
 
       - name: Upload dist zip to GitHub Release
         if: inputs.core_version != ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: cherry-markdown-${{ inputs.core_version }}.zip
           tag_name: 'cherry-markdown@${{ inputs.core_version }}'
+          fail_on_unmatched_files: true


### PR DESCRIPTION
- 用 $GITHUB_WORKSPACE 绝对路径输出 zip，避免相对层级算错（原 ../../ 实际只回退到 packages/）
- 加 fail_on_unmatched_files: true 防止下次再静默丢资产
- 升级 softprops/action-gh-release v2 → v3 (Node 24 runtime)