### PR TITLE
fix(ci): 修复 GitHub Pages 部署路径并包含 logo 资源

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,15 +46,12 @@ jobs:
           mkdir -p gh-pages-out
 
           cp --parents -r packages/cherry-markdown/dist gh-pages-out/
+          cp --parents examples/*.html gh-pages-out/
           cp --parents -r examples/assets gh-pages-out/
-          cp --parents -r logo gh-pages-out/
-
-          # HTML 放根目录，改写 ../ → ./
-          for f in examples/*.html; do
-            sed -E 's|\.\./packages/|./packages/|g; s|\.\./logo/|./logo/|g' "$f" > "gh-pages-out/$(basename $f)"
-          done
-
+          # 可视化配置生成器（目录可能尚未存在，条件复制）
           [ -d examples/config_helper ] && cp --parents -r examples/config_helper gh-pages-out/ || true
+          # logo 资源也复制到 gh-pages-out 根目录
+          cp -r logo gh-pages-out/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,12 +46,15 @@ jobs:
           mkdir -p gh-pages-out
 
           cp --parents -r packages/cherry-markdown/dist gh-pages-out/
-          cp --parents examples/*.html gh-pages-out/
           cp --parents -r examples/assets gh-pages-out/
-          # 可视化配置生成器（目录可能尚未存在，条件复制）
+          cp --parents -r logo gh-pages-out/
+
+          # HTML 放根目录，改写 ../ → ./
+          for f in examples/*.html; do
+            sed -E 's|\.\./packages/|./packages/|g; s|\.\./logo/|./logo/|g' "$f" > "gh-pages-out/$(basename $f)"
+          done
+
           [ -d examples/config_helper ] && cp --parents -r examples/config_helper gh-pages-out/ || true
-          # favicon 等资源（examples/*.html 使用 ../logo/...）
-          cp -r logo gh-pages-out/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -50,8 +50,8 @@ jobs:
           cp --parents -r examples/assets gh-pages-out/
           # 可视化配置生成器（目录可能尚未存在，条件复制）
           [ -d examples/config_helper ] && cp --parents -r examples/config_helper gh-pages-out/ || true
-          # 修复 HTML 中的相对路径
-          find gh-pages-out/examples -type f -name "*.html" -exec sed -i 's|\.\./packages|./packages|g' {} +
+          # favicon 等资源（examples/*.html 使用 ../logo/...）
+          cp -r logo gh-pages-out/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/examples/ai_chat.html
+++ b/examples/ai_chat.html
@@ -83,7 +83,7 @@
       box-sizing: border-box;
     }
   </style>
-  <link rel="Shortcut Icon" href="./logo/favicon.ico">
+  <link rel="Shortcut Icon" href="../logo/favicon.ico">
   <link rel="Shortcut Icon" href="../logo/favicon.ico">
   <link rel="Bookmark" href="../logo/favicon.ico">
 </head>

--- a/examples/ai_chat.html
+++ b/examples/ai_chat.html
@@ -84,8 +84,6 @@
     }
   </style>
   <link rel="Shortcut Icon" href="../logo/favicon.ico">
-  <link rel="Shortcut Icon" href="../logo/favicon.ico">
-  <link rel="Bookmark" href="../logo/favicon.ico">
 </head>
 
 <body>

--- a/examples/ai_chat_stream.html
+++ b/examples/ai_chat_stream.html
@@ -374,7 +374,6 @@
     }
   </style>
   <link rel="Shortcut Icon" href="../logo/favicon.ico">
-  <link rel="Bookmark" href="../logo/favicon.ico">
 </head>
 
 <body>

--- a/examples/api.html
+++ b/examples/api.html
@@ -63,7 +63,7 @@
     }
   </style>
   <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css">
-  <link rel="Shortcut Icon" href="./logo/favicon.ico">
+  <link rel="Shortcut Icon" href="../logo/favicon.ico">
   <link rel="Shortcut Icon" href="../logo/favicon.ico">
   <link rel="Bookmark" href="../logo/favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"

--- a/examples/api.html
+++ b/examples/api.html
@@ -64,8 +64,6 @@
   </style>
   <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css">
   <link rel="Shortcut Icon" href="../logo/favicon.ico">
-  <link rel="Shortcut Icon" href="../logo/favicon.ico">
-  <link rel="Bookmark" href="../logo/favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
     integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
 </head>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cherry Editor - Markdown Editor</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -6,8 +6,6 @@
     <title>Cherry Editor - Markdown Editor</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>
       html {
         height: 100%;

--- a/examples/chart_toolbar_demo.html
+++ b/examples/chart_toolbar_demo.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cherry Markdown - 图表工具栏测试</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>

--- a/examples/chart_toolbar_demo.html
+++ b/examples/chart_toolbar_demo.html
@@ -6,8 +6,6 @@
     <title>Cherry Markdown - 图表工具栏测试</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>
       html,
       body {

--- a/examples/custom_codeblock_wrapper.html
+++ b/examples/custom_codeblock_wrapper.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>自定义代码块外层容器 - Cherry Editor</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>

--- a/examples/custom_codeblock_wrapper.html
+++ b/examples/custom_codeblock_wrapper.html
@@ -6,8 +6,6 @@
     <title>自定义代码块外层容器 - Cherry Editor</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>
       html {
         height: 100%;

--- a/examples/h5.html
+++ b/examples/h5.html
@@ -14,7 +14,7 @@
       }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <link

--- a/examples/h5.html
+++ b/examples/h5.html
@@ -15,8 +15,6 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"

--- a/examples/head_num.html
+++ b/examples/head_num.html
@@ -26,7 +26,7 @@
       }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <link

--- a/examples/head_num.html
+++ b/examples/head_num.html
@@ -27,8 +27,6 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"

--- a/examples/img.html
+++ b/examples/img.html
@@ -20,7 +20,7 @@
       }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
   </head>

--- a/examples/img.html
+++ b/examples/img.html
@@ -21,8 +21,6 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
   </head>
 
   <body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -30,7 +30,7 @@
       }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <!-- <link href="./assets/markdown/index.md" rel="preload" /> -->

--- a/examples/index.html
+++ b/examples/index.html
@@ -31,8 +31,6 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <!-- <link href="./assets/markdown/index.md" rel="preload" /> -->
   </head>
 

--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -17,7 +17,7 @@
       }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <link

--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -18,8 +18,6 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"

--- a/examples/notoolbar.html
+++ b/examples/notoolbar.html
@@ -14,7 +14,7 @@
       }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <link

--- a/examples/notoolbar.html
+++ b/examples/notoolbar.html
@@ -15,8 +15,6 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"

--- a/examples/preview_only.html
+++ b/examples/preview_only.html
@@ -31,7 +31,7 @@
       }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <link

--- a/examples/preview_only.html
+++ b/examples/preview_only.html
@@ -32,8 +32,6 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"

--- a/examples/suggester.html
+++ b/examples/suggester.html
@@ -27,7 +27,7 @@
     }
   </style>
   <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css">
-  <link rel="Shortcut Icon" href="./logo/favicon.ico">
+  <link rel="Shortcut Icon" href="../logo/favicon.ico">
   <link rel="Shortcut Icon" href="../logo/favicon.ico">
   <link rel="Bookmark" href="../logo/favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"

--- a/examples/suggester.html
+++ b/examples/suggester.html
@@ -28,8 +28,6 @@
   </style>
   <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css">
   <link rel="Shortcut Icon" href="../logo/favicon.ico">
-  <link rel="Shortcut Icon" href="../logo/favicon.ico">
-  <link rel="Bookmark" href="../logo/favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
     integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
 </head>

--- a/examples/table.html
+++ b/examples/table.html
@@ -14,7 +14,7 @@
       }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
   </head>

--- a/examples/table.html
+++ b/examples/table.html
@@ -15,8 +15,6 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
   </head>
 
   <body>

--- a/examples/toolbar-toggle-demo.html
+++ b/examples/toolbar-toggle-demo.html
@@ -107,7 +107,7 @@
       #markdown { min-height: 60vh; padding-top: 56px; }
     </style>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" crossorigin="anonymous">
   </head>
 

--- a/examples/vim.html
+++ b/examples/vim.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>VIM demo - Cherry Editor</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>

--- a/examples/vim.html
+++ b/examples/vim.html
@@ -6,8 +6,6 @@
     <title>VIM demo - Cherry Editor</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>
       html {
         height: 100%;

--- a/examples/xss.html
+++ b/examples/xss.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>XSS 白名单对比演示 - Cherry Editor</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
-    <link rel="Shortcut Icon" href="./logo/favicon.ico" />
+    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
     <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>

--- a/examples/xss.html
+++ b/examples/xss.html
@@ -6,8 +6,6 @@
     <title>XSS 白名单对比演示 - Cherry Editor</title>
     <link rel="stylesheet" type="text/css" href="../packages/cherry-markdown/dist/cherry-markdown.css" />
     <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Shortcut Icon" href="../logo/favicon.ico" />
-    <link rel="Bookmark" href="../logo/favicon.ico" />
     <style>
       * {
         margin: 0;


### PR DESCRIPTION
移除错误的 sed 路径替换（examples 下应保持 ../packages），
并复制 logo 目录以修复 favicon 等资源 404。