### PR TITLE
fix: 修复 mermaid 渲染失败后选中编辑框依然渲染漂移

### DIFF
--- a/.changeset/fair-mermaids-float.md
+++ b/.changeset/fair-mermaids-float.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 修复 mermaid 渲染失败后选中编辑框依然渲染漂移

--- a/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
+++ b/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
@@ -81,6 +81,48 @@ export default class MermaidCodeEngine {
   // 上次渲染的代码
   lastRenderedCode = '';
   needReturnLastRenderedCode = false;
+  /** 按 mermaid 源码内容缓存已渲染 HTML，布局参数变更时复用以避免闪回 codeBlock */
+  contentRenderCache = new Map();
+
+  contentRenderCacheMax = 100;
+
+  /**
+   * 生成 mermaid 源码内容缓存 key（与布局 sign 无关）
+   * @param {string} src
+   * @param {import('../Engine').default} $engine
+   * @returns {string}
+   */
+  $getContentCacheKey(src, $engine) {
+    return $engine?.hash?.(src) ?? src;
+  }
+
+  /**
+   * 读取已缓存的 mermaid 渲染结果
+   * @param {string} src
+   * @param {import('../Engine').default} $engine
+   * @returns {string}
+   */
+  $getCachedRenderHtml(src, $engine) {
+    return this.contentRenderCache.get(this.$getContentCacheKey(src, $engine)) || '';
+  }
+
+  /**
+   * 缓存 mermaid 渲染结果（仅缓存含 svg 的成功结果）
+   * @param {string} src
+   * @param {import('../Engine').default} $engine
+   * @param {string} html
+   */
+  $setCachedRenderHtml(src, $engine, html) {
+    if (!html || (!html.includes('<svg') && !html.includes('svg-img'))) {
+      return;
+    }
+    const key = this.$getContentCacheKey(src, $engine);
+    if (this.contentRenderCache.size >= this.contentRenderCacheMax) {
+      const firstKey = this.contentRenderCache.keys().next().value;
+      this.contentRenderCache.delete(firstKey);
+    }
+    this.contentRenderCache.set(key, html);
+  }
 
   /**
    * @param {Object} mermaidOptions - Mermaid 配置选项
@@ -236,6 +278,7 @@ export default class MermaidCodeEngine {
         this.mermaidCanvas,
       );
       this.lastRenderedCode = html;
+      this.$setCachedRenderHtml(src, $engine, html);
     } catch (e) {
       /**
        * 如果开启了流式渲染，当前有上次渲染结果时，使用上次渲染结果
@@ -315,6 +358,10 @@ export default class MermaidCodeEngine {
   }
 
   asyncRender(graphId, src, sign, $engine, props, retryCount = 0) {
+    const cachedHtml = retryCount === 0 ? this.$getCachedRenderHtml(src, $engine) : '';
+    if (cachedHtml) {
+      return cachedHtml;
+    }
     // mermaid 可能是异步加载的，初次调用时 mermaidAPIRefs 可能为 null，这里做延迟重试
     if (!this.mermaidAPIRefs && !this.tryResolveMermaidAPIRefs()) {
       const MAX_RETRY = 60; // 最多重试次数
@@ -343,6 +390,7 @@ export default class MermaidCodeEngine {
         // 渲染完成后，替换为渲染结果
         const html = this.processSvgCode(svgCode, graphId);
         this.lastRenderedCode = html;
+        this.$setCachedRenderHtml(src, $engine, html);
         this.handleAsyncRenderDone(graphId, sign, $engine, props, html);
       })
       .catch(() => {
@@ -377,6 +425,10 @@ export default class MermaidCodeEngine {
     let $sign = sign;
     if (!$sign) {
       $sign = Math.round(Math.random() * 100000000);
+    }
+    const cachedHtml = this.$getCachedRenderHtml(src, $engine);
+    if (cachedHtml) {
+      return cachedHtml;
     }
     this.mountMermaidCanvas($engine);
     // 多实例的情况下相同的内容ID相同会导致mermaid渲染异常

--- a/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
+++ b/packages/cherry-markdown/src/addons/cherry-code-block-mermaid-plugin.js
@@ -301,6 +301,9 @@ export default class MermaidCodeEngine {
     if (isBrowser()) {
       const placeholderList = container.querySelectorAll(`[data-sign="${sign}"][data-type="codeBlock"]`);
       placeholderList?.forEach((placeholder) => {
+        if (placeholder.closest('[data-mode="source"]')) {
+          return;
+        }
         if (isToolbarMode) {
           // showSourceToolbar 模式：仅替换预览面板内容，保留工具栏和源码面板
           const previewPanel = placeholder.parentElement

--- a/packages/cherry-markdown/src/toolbars/MermaidBubbleSession.js
+++ b/packages/cherry-markdown/src/toolbars/MermaidBubbleSession.js
@@ -201,25 +201,25 @@ export default class MermaidBubbleSession {
   }
 
   clearPositionSyncTimer() {
-    if (this._positionSyncTimer) {
-      clearTimeout(this._positionSyncTimer);
-      this._positionSyncTimer = null;
+    if (this.positionSyncTimer) {
+      clearTimeout(this.positionSyncTimer);
+      this.positionSyncTimer = null;
     }
   }
 
   clearAsyncValidityTimer() {
-    if (this._asyncValidityTimer) {
-      clearTimeout(this._asyncValidityTimer);
-      this._asyncValidityTimer = null;
+    if (this.asyncValidityTimer) {
+      clearTimeout(this.asyncValidityTimer);
+      this.asyncValidityTimer = null;
     }
   }
 
   clearPositionTransitionListener() {
-    if (this._positionTransitionFigure && this._positionTransitionHandler) {
-      this._positionTransitionFigure.removeEventListener('transitionend', this._positionTransitionHandler);
+    if (this.positionTransitionFigure && this.positionTransitionHandler) {
+      this.positionTransitionFigure.removeEventListener('transitionend', this.positionTransitionHandler);
     }
-    this._positionTransitionFigure = null;
-    this._positionTransitionHandler = null;
+    this.positionTransitionFigure = null;
+    this.positionTransitionHandler = null;
   }
 
   /**
@@ -249,11 +249,11 @@ export default class MermaidBubbleSession {
       return;
     }
 
-    this._positionTransitionFigure = figure;
-    this._positionTransitionHandler = sync;
+    this.positionTransitionFigure = figure;
+    this.positionTransitionHandler = sync;
     figure.addEventListener('transitionend', sync, { once: true });
-    this._positionSyncTimer = setTimeout(() => {
-      this._positionSyncTimer = null;
+    this.positionSyncTimer = setTimeout(() => {
+      this.positionSyncTimer = null;
       sync();
     }, 120);
   }
@@ -279,8 +279,8 @@ export default class MermaidBubbleSession {
     const maxAttempts = 8;
     const delay = attempt === 0 ? 0 : 50;
 
-    this._asyncValidityTimer = setTimeout(() => {
-      this._asyncValidityTimer = null;
+    this.asyncValidityTimer = setTimeout(() => {
+      this.asyncValidityTimer = null;
       if (!this.isActive()) {
         return;
       }

--- a/packages/cherry-markdown/src/toolbars/MermaidBubbleSession.js
+++ b/packages/cherry-markdown/src/toolbars/MermaidBubbleSession.js
@@ -1,0 +1,307 @@
+/**
+ * mermaid 预览操作框会话
+ *
+ * 维护说明：
+ * - 编辑器解析、布局参数 → @/utils/mermaidEditorHelper
+ * - 预览可见性、figure 查找 → @/utils/mermaidPreviewHelper
+ * - 本类只负责会话状态、rebind、双控件位置同步与生命周期校验
+ */
+
+import imgSizeHandler from '@/utils/imgSizeHandler';
+import imgToolHandler from '@/utils/imgToolHandler';
+import { buildMermaidEditContext, findMermaidBlockIndexByCodeBody } from '@/utils/mermaidEditorHelper';
+import { countMermaidFigures, getMermaidFigureByIndex, isMermaidPreviewVisible } from '@/utils/mermaidPreviewHelper';
+
+export default class MermaidBubbleSession {
+  /**
+   * @param {import('./PreviewerBubble').default} host PreviewerBubble 实例
+   */
+  constructor(host) {
+    this.host = host;
+    this.reset();
+  }
+
+  /** 重置会话状态（移除操作框时调用） */
+  reset() {
+    this.anchorBody = '';
+    this.previewIndex = -1;
+    this.selfEditing = false;
+    this.size = '';
+    this.align = '';
+    this.extendFrom = 0;
+    this.extendTo = 0;
+    this.hasExtend = false;
+    this.langLineNum = -1;
+    this.clearPositionSyncTimer();
+  }
+
+  /** 当前是否处于 mermaid 操作框会话 */
+  isActive() {
+    const { bubbleHandler } = this.host;
+    return bubbleHandler.click === imgSizeHandler && imgSizeHandler.isMermaid;
+  }
+
+  /**
+   * 选中 mermaid 时初始化编辑上下文
+   * @param {HTMLElement} figureElement
+   * @returns {boolean}
+   */
+  beginEdit(figureElement) {
+    const { previewerDom, editor } = this.host;
+    if (!editor?.editor) {
+      return false;
+    }
+
+    const allFigures = Array.from(previewerDom.querySelectorAll('figure[data-type="mermaid"]'));
+    const previewIndex = allFigures.indexOf(figureElement);
+    if (previewIndex < 0) {
+      return false;
+    }
+
+    const rawContent = editor.editor.view.state.doc.toString();
+    const context = buildMermaidEditContext(rawContent, previewIndex, editor.editor.view.state.doc);
+    if (!context) {
+      return false;
+    }
+
+    this.previewIndex = context.previewIndex;
+    this.anchorBody = context.anchorBody;
+    this.langLineNum = context.langLineNum;
+    this.extendFrom = context.extendFrom;
+    this.extendTo = context.extendTo;
+    this.size = context.size;
+    this.align = context.align;
+    this.hasExtend = context.hasExtend;
+
+    if (this.hasExtend) {
+      editor.editor.setSelection(this.extendFrom, this.extendTo);
+    } else {
+      editor.editor.setSelection(this.extendFrom, this.extendFrom);
+    }
+
+    return true;
+  }
+
+  /** 注入 handler 的校验/解析回调 */
+  createHandlerOptions(onInvalidTarget) {
+    return {
+      onInvalidTarget,
+      validateTarget: () => this.isValid({ strict: false }),
+      resolveTarget: () => this.resolveFigure(),
+    };
+  }
+
+  /** 绑定 imgSizeHandler 拖拽时同步方向控制器 */
+  bindPositionFollow() {
+    imgSizeHandler.onPositionUpdated = () => {
+      if (this.host.bubbleHandler.imgTool !== imgToolHandler) {
+        return;
+      }
+      imgToolHandler.refreshTarget();
+      imgToolHandler.updatePosition();
+    };
+  }
+
+  /** 清理 timer 与联动回调（imgSizeHandler.remove 时调用） */
+  disposeHandlers() {
+    this.clearPositionSyncTimer();
+    imgSizeHandler.onPositionUpdated = null;
+  }
+
+  /**
+   * 按编辑器源码锚点解析 index
+   * @returns {number}
+   */
+  getEditorIndex() {
+    const { editor } = this.host;
+    if (!editor?.editor || !this.anchorBody) {
+      return -1;
+    }
+    return findMermaidBlockIndexByCodeBody(editor.editor.view.state.doc.toString(), this.anchorBody);
+  }
+
+  /**
+   * 预览刷新后 rebind figure
+   * @returns {HTMLElement | null}
+   */
+  resolveFigure() {
+    if (!imgSizeHandler.isMermaid) {
+      return imgSizeHandler.img;
+    }
+
+    const editorIndex = this.getEditorIndex();
+    if (editorIndex < 0) {
+      return null;
+    }
+
+    this.previewIndex = editorIndex;
+    const { previewerDom } = this.host;
+    if (editorIndex >= countMermaidFigures(previewerDom)) {
+      return null;
+    }
+
+    const current = getMermaidFigureByIndex(previewerDom, editorIndex);
+    if (!current) {
+      return null;
+    }
+
+    imgSizeHandler.img = current;
+    if (this.host.bubbleHandler.imgTool === imgToolHandler) {
+      imgToolHandler.img = current;
+    }
+    return current;
+  }
+
+  /**
+   * 校验操作框是否仍有效
+   * @param {{ strict?: boolean }} [options]
+   * @returns {boolean}
+   */
+  isValid(options = {}) {
+    const { strict = false } = options;
+    if (imgSizeHandler.$isResizing()) {
+      return true;
+    }
+
+    const editorIndex = this.getEditorIndex();
+    const target = this.resolveFigure();
+
+    if (!strict && this.selfEditing) {
+      return editorIndex >= 0;
+    }
+
+    if (editorIndex < 0) {
+      return false;
+    }
+
+    if (!target || !document.contains(target) || !this.host.previewerDom.contains(target)) {
+      return false;
+    }
+
+    return isMermaidPreviewVisible(target, this.host.previewerDom);
+  }
+
+  /** 同步选择框与方向控制器位置 */
+  applyHandlerPositions() {
+    if (!imgSizeHandler.$isResizing()) {
+      imgSizeHandler.updatePosition();
+    }
+    if (this.host.bubbleHandler.imgTool === imgToolHandler) {
+      imgToolHandler.refreshTarget();
+      imgToolHandler.updatePosition();
+    }
+  }
+
+  clearPositionSyncTimer() {
+    if (this._positionSyncTimer) {
+      clearTimeout(this._positionSyncTimer);
+      this._positionSyncTimer = null;
+    }
+  }
+
+  /**
+   * 等待 figure 过渡结束后统一更新位置
+   * @param {() => void} [onInvalidTarget]
+   */
+  schedulePositionSync(onInvalidTarget) {
+    if (!this.isActive() || imgSizeHandler.$isResizing()) {
+      return;
+    }
+
+    imgSizeHandler.$clearPreviewUpdateTimer?.();
+    this.clearPositionSyncTimer();
+
+    const sync = () => {
+      if (!this.isValid({ strict: false })) {
+        (onInvalidTarget || this.host.$removeImgPreviewerBubbles.bind(this.host))();
+        return;
+      }
+      this.applyHandlerPositions();
+    };
+
+    const figure = imgSizeHandler.img;
+    if (!figure) {
+      sync();
+      return;
+    }
+
+    figure.addEventListener('transitionend', sync, { once: true });
+    this._positionSyncTimer = setTimeout(() => {
+      this._positionSyncTimer = null;
+      sync();
+    }, 120);
+  }
+
+  /** 预览 DOM 更新后 */
+  onPreviewUpdate() {
+    this.resolveFigure();
+    this.schedulePositionSync(() => this.host.$removeImgPreviewerBubbles());
+  }
+
+  /** mermaid 异步渲染 patch DOM 后 */
+  onAsyncRenderDone() {
+    this.onPreviewUpdate();
+    this.host.$checkAndRemoveInvalidImgHandlers({ strict: true });
+    this.clearSelfEditingIfReady();
+  }
+
+  /** 布局编辑完成且 svg 可见时清除 selfEditing 标记 */
+  clearSelfEditingIfReady() {
+    if (!this.selfEditing || !this.isActive()) {
+      this.selfEditing = false;
+      return;
+    }
+    const target = this.resolveFigure();
+    if (target && isMermaidPreviewVisible(target, this.host.previewerDom)) {
+      this.selfEditing = false;
+    }
+  }
+
+  /** 写入布局参数到编辑器语言行 */
+  applyLayoutValue() {
+    this.selfEditing = true;
+    const { editor } = this.host;
+    if (!editor?.editor) {
+      return;
+    }
+
+    const value = [this.size, this.align].filter((v) => v).join(' ');
+
+    if (this.hasExtend) {
+      editor.editor.setSelection(this.extendFrom, this.extendTo);
+      editor.editor.replaceSelection(value, 'around');
+      this.extendTo = this.extendFrom + value.length;
+    } else if (value) {
+      editor.editor.setSelection(this.extendFrom, this.extendFrom);
+      editor.editor.replaceSelection(` ${value}`, 'around');
+      this.extendFrom += 1;
+      this.extendTo = this.extendFrom + value.length;
+      this.hasExtend = true;
+    }
+  }
+
+  /** @param {{ width: number, height: number }} style */
+  changeSize(style) {
+    this.size = `#${Math.round(style.width)}px #${Math.round(style.height)}px`;
+    this.applyLayoutValue();
+  }
+
+  /** @param {string} type */
+  changeAlign(type) {
+    switch (type) {
+      case 'left':
+      case 'right':
+      case 'center':
+      case 'float-left':
+      case 'float-right':
+        this.align = `#${type}`;
+        break;
+      case 'clear-align':
+        this.align = '';
+        break;
+      default:
+        return;
+    }
+    this.applyLayoutValue();
+  }
+}

--- a/packages/cherry-markdown/src/toolbars/MermaidBubbleSession.js
+++ b/packages/cherry-markdown/src/toolbars/MermaidBubbleSession.js
@@ -24,6 +24,7 @@ export default class MermaidBubbleSession {
   /** 重置会话状态（移除操作框时调用） */
   reset() {
     this.anchorBody = '';
+    this.anchorPreviewIndex = -1;
     this.previewIndex = -1;
     this.selfEditing = false;
     this.size = '';
@@ -33,6 +34,8 @@ export default class MermaidBubbleSession {
     this.hasExtend = false;
     this.langLineNum = -1;
     this.clearPositionSyncTimer();
+    this.clearAsyncValidityTimer();
+    this.clearPositionTransitionListener();
   }
 
   /** 当前是否处于 mermaid 操作框会话 */
@@ -66,6 +69,7 @@ export default class MermaidBubbleSession {
 
     this.previewIndex = context.previewIndex;
     this.anchorBody = context.anchorBody;
+    this.anchorPreviewIndex = context.previewIndex;
     this.langLineNum = context.langLineNum;
     this.extendFrom = context.extendFrom;
     this.extendTo = context.extendTo;
@@ -117,7 +121,11 @@ export default class MermaidBubbleSession {
     if (!editor?.editor || !this.anchorBody) {
       return -1;
     }
-    return findMermaidBlockIndexByCodeBody(editor.editor.view.state.doc.toString(), this.anchorBody);
+    return findMermaidBlockIndexByCodeBody(
+      editor.editor.view.state.doc.toString(),
+      this.anchorBody,
+      this.anchorPreviewIndex,
+    );
   }
 
   /**
@@ -199,6 +207,21 @@ export default class MermaidBubbleSession {
     }
   }
 
+  clearAsyncValidityTimer() {
+    if (this._asyncValidityTimer) {
+      clearTimeout(this._asyncValidityTimer);
+      this._asyncValidityTimer = null;
+    }
+  }
+
+  clearPositionTransitionListener() {
+    if (this._positionTransitionFigure && this._positionTransitionHandler) {
+      this._positionTransitionFigure.removeEventListener('transitionend', this._positionTransitionHandler);
+    }
+    this._positionTransitionFigure = null;
+    this._positionTransitionHandler = null;
+  }
+
   /**
    * 等待 figure 过渡结束后统一更新位置
    * @param {() => void} [onInvalidTarget]
@@ -210,6 +233,7 @@ export default class MermaidBubbleSession {
 
     imgSizeHandler.$clearPreviewUpdateTimer?.();
     this.clearPositionSyncTimer();
+    this.clearPositionTransitionListener();
 
     const sync = () => {
       if (!this.isValid({ strict: false })) {
@@ -225,6 +249,8 @@ export default class MermaidBubbleSession {
       return;
     }
 
+    this._positionTransitionFigure = figure;
+    this._positionTransitionHandler = sync;
     figure.addEventListener('transitionend', sync, { once: true });
     this._positionSyncTimer = setTimeout(() => {
       this._positionSyncTimer = null;
@@ -241,8 +267,34 @@ export default class MermaidBubbleSession {
   /** mermaid 异步渲染 patch DOM 后 */
   onAsyncRenderDone() {
     this.onPreviewUpdate();
-    this.host.$checkAndRemoveInvalidImgHandlers({ strict: true });
-    this.clearSelfEditingIfReady();
+    this.scheduleAsyncValidityCheck();
+  }
+
+  /**
+   * fix(MermaidBubbleSession): 邻居块异步恢复会触发布局重排，延迟校验避免误关选中框
+   * @param {number} [attempt]
+   */
+  scheduleAsyncValidityCheck(attempt = 0) {
+    this.clearAsyncValidityTimer();
+    const maxAttempts = 8;
+    const delay = attempt === 0 ? 0 : 50;
+
+    this._asyncValidityTimer = setTimeout(() => {
+      this._asyncValidityTimer = null;
+      if (!this.isActive()) {
+        return;
+      }
+      this.resolveFigure();
+      if (this.isValid({ strict: true })) {
+        this.clearSelfEditingIfReady();
+        return;
+      }
+      if (attempt >= maxAttempts) {
+        this.host.$checkAndRemoveInvalidImgHandlers({ strict: true });
+        return;
+      }
+      this.scheduleAsyncValidityCheck(attempt + 1);
+    }, delay);
   }
 
   /** 布局编辑完成且 svg 可见时清除 selfEditing 标记 */

--- a/packages/cherry-markdown/src/toolbars/MermaidBubbleSession.js
+++ b/packages/cherry-markdown/src/toolbars/MermaidBubbleSession.js
@@ -2,8 +2,8 @@
  * mermaid 预览操作框会话
  *
  * 维护说明：
- * - 编辑器解析、布局参数 → @/utils/mermaidEditorHelper
- * - 预览可见性、figure 查找 → @/utils/mermaidPreviewHelper
+ * - 编辑器解析、布局参数 → utils/mermaidEditorHelper
+ * - 预览可见性、figure 查找 → utils/mermaidPreviewHelper
  * - 本类只负责会话状态、rebind、双控件位置同步与生命周期校验
  */
 

--- a/packages/cherry-markdown/src/toolbars/PreviewerBubble.js
+++ b/packages/cherry-markdown/src/toolbars/PreviewerBubble.js
@@ -16,6 +16,7 @@
 
 import imgSizeHandler from '@/utils/imgSizeHandler';
 import imgToolHandler from '@/utils/imgToolHandler';
+import { isMermaidPreviewVisible } from '@/utils/mermaidPreviewHelper';
 import { Transaction } from '@codemirror/state';
 import TableHandler from '@/utils/tableContentHandler';
 import FootnoteHoverHandler from '@/utils/footnoteHoverHandler';
@@ -116,11 +117,19 @@ export default class PreviewerBubble {
     this.previewer.options.afterUpdateCallBack.push(() => {
       // 检查表格处理器是否需要重新创建
       this.$checkAndRecreateTableHandlers();
+      // 预览区 DOM 更新后，检查图片/mermaid 选中目标是否仍存在（如左侧已删除整个 mermaid 块）
+      this.$checkAndRemoveInvalidImgHandlers();
 
       Object.values(this.bubbleHandler).forEach((handler) =>
-        handler.emit('previewUpdate', () => this.$removeAllPreviewerBubbles()),
+        handler.emit('previewUpdate', () => this.$removeImgPreviewerBubbles()),
       );
     });
+    // 编辑器内容变更并完成预览同步后，再次校验（兜底 afterUpdateCallBack 未触发的场景）
+    this.$bindedOnAfterChange = () => this.$checkAndRemoveInvalidImgHandlers();
+    this.$cherry.$event.on('afterChange', this.$bindedOnAfterChange);
+    // mermaid 异步渲染/失败回退会直接改 DOM，不经过 previewer.update，需单独监听
+    this.$bindedOnAfterAsyncRender = () => this.$checkAndRemoveInvalidImgHandlers({ strict: true });
+    this.$cherry.$event.on('afterAsyncRender', this.$bindedOnAfterAsyncRender);
     this.previewerDom.addEventListener('change', this.$bindedOnChange);
     this.removeHoverBubble = debounce(() => this.$removeAllPreviewerBubbles('hover'), 400);
 
@@ -554,18 +563,34 @@ export default class PreviewerBubble {
   }
 
   /**
+   * click 气泡与 imgTool 成对出现，移除 click 时需一并清理 imgTool
+   * @param {string} key 气泡 trigger 键名
+   * @param {string} trigger 当前指定的移除范围
+   * @returns {boolean}
+   */
+  $shouldRemoveBubbleKey(key, trigger) {
+    if (!trigger) {
+      return true;
+    }
+    if (trigger === 'click') {
+      return key === 'click' || key === 'imgTool';
+    }
+    return key === trigger;
+  }
+
+  /**
    * 隐藏预览区域已经激活的工具栏
    * @param {string} trigger 移除指定的触发方式，不传默认全部移除
    */
   $removeAllPreviewerBubbles(trigger = '') {
     Object.entries(this.bubble)
-      .filter(([key]) => !trigger || trigger === key)
+      .filter(([key]) => this.$shouldRemoveBubbleKey(key, trigger))
       .forEach(([key, value]) => {
         value.remove();
         delete this.bubble[key];
       });
     Object.entries(this.bubbleHandler)
-      .filter(([key]) => !trigger || trigger === key)
+      .filter(([key]) => this.$shouldRemoveBubbleKey(key, trigger))
       .forEach(([key, value]) => {
         value.emit('remove');
         delete this.bubbleHandler[key];
@@ -573,6 +598,17 @@ export default class PreviewerBubble {
     if (Object.keys(this.bubbleHandler).length <= 0 && this.previewer?.$cherry?.wrapperDom) {
       this.previewer.$cherry.wrapperDom.style.overflow = this.oldWrapperDomOverflow || '';
     }
+    if (!trigger || trigger === 'click') {
+      this.mermaidFigure = null;
+      this.mermaidTargetFigure = null;
+    }
+  }
+
+  /**
+   * 移除图片/mermaid 编辑相关的气泡（选择框 + 对齐工具栏）
+   */
+  $removeImgPreviewerBubbles() {
+    this.$removeAllPreviewerBubbles('click');
   }
 
   /**
@@ -590,6 +626,116 @@ export default class PreviewerBubble {
         }
       }
     });
+  }
+
+  /**
+   * 按索引获取预览区中当前的 mermaid figure
+   * @returns {HTMLElement | null}
+   */
+  $getMermaidFigureAtIndex() {
+    if (this.mermaidIndex < 0) {
+      return null;
+    }
+    const figures = this.previewerDom.querySelectorAll('figure[data-type="mermaid"]');
+    return /** @type {HTMLElement | null} */ (figures[this.mermaidIndex] || null);
+  }
+
+  /**
+   * 预览刷新后按索引重新绑定 mermaid figure（避免引用已替换的旧 DOM）
+   * @returns {HTMLElement | null | undefined}
+   */
+  $resolveMermaidTargetFigure() {
+    if (!imgSizeHandler.isMermaid) {
+      return imgSizeHandler.img;
+    }
+    const current = this.$getMermaidFigureAtIndex();
+    if (current) {
+      this.mermaidTargetFigure = current;
+      imgSizeHandler.img = current;
+      if (this.bubbleHandler.imgTool === imgToolHandler) {
+        imgToolHandler.img = current;
+      }
+      return current;
+    }
+    return this.mermaidTargetFigure || imgSizeHandler.img;
+  }
+
+  /**
+   * 编辑器中是否仍存在当前索引对应的 mermaid 代码块
+   * @returns {boolean}
+   */
+  $isMermaidBlockStillInEditor() {
+    if (!this.$hasEditor() || this.mermaidIndex < 0) {
+      return false;
+    }
+    const rawContent = this.editor.editor.view.state.doc.toString();
+    const codeBlockReg = /(?:^|\n)(\n*(?:>[\t ]*)*(?:[^\S\n]*))(`{3,})([^`]*?)\n([\w\W]*?)\n\s*\2[ \t]*(?=$|\n)/g;
+    let match;
+    let currentMermaidIdx = -1;
+
+    while ((match = codeBlockReg.exec(rawContent)) !== null) {
+      const langLine = match[3].trim().toLowerCase();
+      const langPure = langLine
+        .replace(/#([0-9]+(px|em|pt|pc|in|mm|cm|ex|%)|auto)/gi, '')
+        .replace(/#(center|right|left|float-right|float-left)/gi, '')
+        .trim();
+
+      if (langPure !== 'mermaid' && !/^flow([ ](td|lr))?$/i.test(langPure) && langPure !== 'seq') {
+        continue;
+      }
+      currentMermaidIdx += 1;
+      if (currentMermaidIdx === this.mermaidIndex) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * 检查图片/mermaid 尺寸处理器是否仍然有效
+   * @param {{ strict?: boolean }} [options] strict=true 时在异步渲染完成后严格校验预览内容
+   * @returns {boolean}
+   */
+  $isImgHandlerValid(options = {}) {
+    const { strict = false } = options;
+    if (this.bubbleHandler.click !== imgSizeHandler) {
+      return true;
+    }
+    if (imgSizeHandler.$isResizing()) {
+      return true;
+    }
+
+    const target = imgSizeHandler.isMermaid ? this.$resolveMermaidTargetFigure() : imgSizeHandler.img;
+    if (!target || !document.contains(target) || !this.previewerDom.contains(target)) {
+      return false;
+    }
+
+    if (imgSizeHandler.isMermaid) {
+      // 布局调整触发的预览刷新：figure 与源码块仍在时，异步重绘期间 svg 可能暂时消失
+      if (!strict && this.$getMermaidFigureAtIndex() && this.$isMermaidBlockStillInEditor()) {
+        return true;
+      }
+      return isMermaidPreviewVisible(/** @type {HTMLElement} */ (target), this.previewerDom);
+    }
+
+    if (target.tagName !== 'IMG') {
+      return false;
+    }
+    const rect = target.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  /**
+   * 预览区更新后检查图片/mermaid 选中目标是否仍可编辑
+   * @param {{ strict?: boolean }} [options]
+   */
+  $checkAndRemoveInvalidImgHandlers(options = {}) {
+    if (this.bubbleHandler.click !== imgSizeHandler) {
+      return;
+    }
+    if (!this.$isImgHandlerValid(options)) {
+      this.$removeImgPreviewerBubbles();
+    }
   }
 
   /**
@@ -734,16 +880,22 @@ export default class PreviewerBubble {
       return { emit: () => {} };
     }
 
+    const onInvalidTarget = () => this.$removeImgPreviewerBubbles();
+    const validateTarget = () => this.$isImgHandlerValid();
+
     const imgSizeDiv = document.createElement('div');
     imgSizeDiv.className = 'cherry-previewer-img-size-handler';
     this.bubble.click.appendChild(imgSizeDiv);
-    imgSizeHandler.showBubble(htmlElement, imgSizeDiv, this.previewerDom);
+    imgSizeHandler.showBubble(htmlElement, imgSizeDiv, this.previewerDom, { onInvalidTarget, validateTarget });
     imgSizeHandler.bindChange(this.changeImgSize.bind(this));
 
     const imgToolDiv = document.createElement('div');
     imgToolDiv.className = 'cherry-previewer-img-tool-handler';
     this.bubble.click.appendChild(imgToolDiv);
-    imgToolHandler.showBubble(htmlElement, imgToolDiv, this.previewerDom, event, this.previewer.$cherry.getLocales());
+    imgToolHandler.showBubble(htmlElement, imgToolDiv, this.previewerDom, event, this.previewer.$cherry.getLocales(), {
+      onInvalidTarget,
+      validateTarget,
+    });
     imgToolHandler.bindChange(this.changeImgStyle.bind(this));
 
     // 订阅编辑器大小变化事件
@@ -1085,9 +1237,13 @@ export default class PreviewerBubble {
     this.$createPreviewerBubbles('click', 'img-handler');
 
     this.mermaidFigure = figureElement;
+    this.mermaidTargetFigure = figureElement;
     if (!this.beginChangeMermaidValue(figureElement)) {
       return;
     }
+
+    const onInvalidTarget = () => this.$removeImgPreviewerBubbles();
+    const validateTarget = () => this.$isImgHandlerValid();
 
     const imgSizeDiv = document.createElement('div');
     imgSizeDiv.className = 'cherry-previewer-img-size-handler';
@@ -1095,6 +1251,8 @@ export default class PreviewerBubble {
     imgSizeHandler.showBubble(figureElement, imgSizeDiv, this.previewerDom, {
       isMermaid: true,
       targetIndex: this.mermaidIndex,
+      onInvalidTarget,
+      validateTarget,
     });
     imgSizeHandler.bindChange(this.changeMermaidSize.bind(this));
 
@@ -1108,7 +1266,7 @@ export default class PreviewerBubble {
       this.previewerDom,
       event,
       this.previewer.$cherry.getLocales(),
-      { isMermaid: true, targetIndex: this.mermaidIndex },
+      { isMermaid: true, targetIndex: this.mermaidIndex, onInvalidTarget, validateTarget },
     );
     imgToolHandler.bindChange(this.changeMermaidStyle.bind(this));
 
@@ -1334,6 +1492,8 @@ export default class PreviewerBubble {
     if (this.$cherry && this.$cherry.$event) {
       this.$cherry.$event.off('editor.size.change', this.$bindedOnEditorSizeChange);
       this.$cherry.$event.off('layoutChange', this.$bindedOnLayoutChange);
+      this.$cherry.$event.off('afterChange', this.$bindedOnAfterChange);
+      this.$cherry.$event.off('afterAsyncRender', this.$bindedOnAfterAsyncRender);
     }
 
     // 清理引用
@@ -1347,6 +1507,8 @@ export default class PreviewerBubble {
     this.$bindedOnChange = null;
     this.$bindedOnEditorSizeChange = null;
     this.$bindedOnLayoutChange = null;
+    this.$bindedOnAfterChange = null;
+    this.$bindedOnAfterAsyncRender = null;
 
     this.bubble = {};
     this.bubbleHandler = {};

--- a/packages/cherry-markdown/src/toolbars/PreviewerBubble.js
+++ b/packages/cherry-markdown/src/toolbars/PreviewerBubble.js
@@ -16,7 +16,7 @@
 
 import imgSizeHandler from '@/utils/imgSizeHandler';
 import imgToolHandler from '@/utils/imgToolHandler';
-import { isMermaidPreviewVisible } from '@/utils/mermaidPreviewHelper';
+import MermaidBubbleSession from '@/toolbars/MermaidBubbleSession';
 import { Transaction } from '@codemirror/state';
 import TableHandler from '@/utils/tableContentHandler';
 import FootnoteHoverHandler from '@/utils/footnoteHoverHandler';
@@ -67,6 +67,8 @@ export default class PreviewerBubble {
     this.imgLeadingSpacePos = -1;
     /** 记录 beginChangeImgValue 时的文档状态，用于位置映射追踪 */
     this.imgChangeBaseState = null;
+    /** @type {MermaidBubbleSession} */
+    this.mermaidSession = new MermaidBubbleSession(this);
     this.init();
   }
 
@@ -117,18 +119,33 @@ export default class PreviewerBubble {
     this.previewer.options.afterUpdateCallBack.push(() => {
       // 检查表格处理器是否需要重新创建
       this.$checkAndRecreateTableHandlers();
-      // 预览区 DOM 更新后，检查图片/mermaid 选中目标是否仍存在（如左侧已删除整个 mermaid 块）
-      this.$checkAndRemoveInvalidImgHandlers();
 
-      Object.values(this.bubbleHandler).forEach((handler) =>
-        handler.emit('previewUpdate', () => this.$removeImgPreviewerBubbles()),
-      );
+      if (this.mermaidSession.isActive()) {
+        this.mermaidSession.onPreviewUpdate();
+      } else {
+        Object.values(this.bubbleHandler).forEach((handler) =>
+          handler.emit('previewUpdate', () => this.$removeImgPreviewerBubbles()),
+        );
+      }
+
+      this.$checkAndRemoveInvalidImgHandlers();
+      this.mermaidSession.clearSelfEditingIfReady();
     });
-    // 编辑器内容变更并完成预览同步后，再次校验（兜底 afterUpdateCallBack 未触发的场景）
-    this.$bindedOnAfterChange = () => this.$checkAndRemoveInvalidImgHandlers();
+    // 预览隐藏时 afterUpdate 不会刷新 DOM，仅在此时做兜底校验
+    this.$bindedOnAfterChange = () => {
+      if (this.previewer?.isPreviewerHidden?.()) {
+        this.$checkAndRemoveInvalidImgHandlers();
+      }
+    };
     this.$cherry.$event.on('afterChange', this.$bindedOnAfterChange);
     // mermaid 异步渲染/失败回退会直接改 DOM，不经过 previewer.update，需单独监听
-    this.$bindedOnAfterAsyncRender = () => this.$checkAndRemoveInvalidImgHandlers({ strict: true });
+    this.$bindedOnAfterAsyncRender = () => {
+      if (this.mermaidSession.isActive()) {
+        this.mermaidSession.onAsyncRenderDone();
+      } else {
+        this.$checkAndRemoveInvalidImgHandlers({ strict: true });
+      }
+    };
     this.$cherry.$event.on('afterAsyncRender', this.$bindedOnAfterAsyncRender);
     this.previewerDom.addEventListener('change', this.$bindedOnChange);
     this.removeHoverBubble = debounce(() => this.$removeAllPreviewerBubbles('hover'), 400);
@@ -599,8 +616,7 @@ export default class PreviewerBubble {
       this.previewer.$cherry.wrapperDom.style.overflow = this.oldWrapperDomOverflow || '';
     }
     if (!trigger || trigger === 'click') {
-      this.mermaidFigure = null;
-      this.mermaidTargetFigure = null;
+      this.mermaidSession.reset();
     }
   }
 
@@ -629,93 +645,25 @@ export default class PreviewerBubble {
   }
 
   /**
-   * 按索引获取预览区中当前的 mermaid figure
-   * @returns {HTMLElement | null}
-   */
-  $getMermaidFigureAtIndex() {
-    if (this.mermaidIndex < 0) {
-      return null;
-    }
-    const figures = this.previewerDom.querySelectorAll('figure[data-type="mermaid"]');
-    return /** @type {HTMLElement | null} */ (figures[this.mermaidIndex] || null);
-  }
-
-  /**
-   * 预览刷新后按索引重新绑定 mermaid figure（避免引用已替换的旧 DOM）
-   * @returns {HTMLElement | null | undefined}
-   */
-  $resolveMermaidTargetFigure() {
-    if (!imgSizeHandler.isMermaid) {
-      return imgSizeHandler.img;
-    }
-    const current = this.$getMermaidFigureAtIndex();
-    if (current) {
-      this.mermaidTargetFigure = current;
-      imgSizeHandler.img = current;
-      if (this.bubbleHandler.imgTool === imgToolHandler) {
-        imgToolHandler.img = current;
-      }
-      return current;
-    }
-    return this.mermaidTargetFigure || imgSizeHandler.img;
-  }
-
-  /**
-   * 编辑器中是否仍存在当前索引对应的 mermaid 代码块
-   * @returns {boolean}
-   */
-  $isMermaidBlockStillInEditor() {
-    if (!this.$hasEditor() || this.mermaidIndex < 0) {
-      return false;
-    }
-    const rawContent = this.editor.editor.view.state.doc.toString();
-    const codeBlockReg = /(?:^|\n)(\n*(?:>[\t ]*)*(?:[^\S\n]*))(`{3,})([^`]*?)\n([\w\W]*?)\n\s*\2[ \t]*(?=$|\n)/g;
-    let match;
-    let currentMermaidIdx = -1;
-
-    while ((match = codeBlockReg.exec(rawContent)) !== null) {
-      const langLine = match[3].trim().toLowerCase();
-      const langPure = langLine
-        .replace(/#([0-9]+(px|em|pt|pc|in|mm|cm|ex|%)|auto)/gi, '')
-        .replace(/#(center|right|left|float-right|float-left)/gi, '')
-        .trim();
-
-      if (langPure !== 'mermaid' && !/^flow([ ](td|lr))?$/i.test(langPure) && langPure !== 'seq') {
-        continue;
-      }
-      currentMermaidIdx += 1;
-      if (currentMermaidIdx === this.mermaidIndex) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * 检查图片/mermaid 尺寸处理器是否仍然有效
    * @param {{ strict?: boolean }} [options] strict=true 时在异步渲染完成后严格校验预览内容
    * @returns {boolean}
    */
   $isImgHandlerValid(options = {}) {
-    const { strict = false } = options;
     if (this.bubbleHandler.click !== imgSizeHandler) {
       return true;
     }
+    if (imgSizeHandler.isMermaid && this.mermaidSession.isActive()) {
+      return this.mermaidSession.isValid(options);
+    }
+
     if (imgSizeHandler.$isResizing()) {
       return true;
     }
 
-    const target = imgSizeHandler.isMermaid ? this.$resolveMermaidTargetFigure() : imgSizeHandler.img;
+    const target = imgSizeHandler.img;
     if (!target || !document.contains(target) || !this.previewerDom.contains(target)) {
       return false;
-    }
-
-    if (imgSizeHandler.isMermaid) {
-      // 布局调整触发的预览刷新：figure 与源码块仍在时，异步重绘期间 svg 可能暂时消失
-      if (!strict && this.$getMermaidFigureAtIndex() && this.$isMermaidBlockStillInEditor()) {
-        return true;
-      }
-      return isMermaidPreviewVisible(/** @type {HTMLElement} */ (target), this.previewerDom);
     }
 
     if (target.tagName !== 'IMG') {
@@ -1224,6 +1172,8 @@ export default class PreviewerBubble {
 
   /**
    * 为选中的 mermaid 图表增加尺寸调整工具
+   *
+   * fix(PreviewerBubble): mermaid 会话逻辑见 MermaidBubbleSession，编辑器解析见 mermaidEditorHelper
    * @param {HTMLElement} figureElement mermaid 图表的 figure DOM
    */
   $showMermaidPreviewerBubbles(figureElement, event) {
@@ -1236,25 +1186,23 @@ export default class PreviewerBubble {
     }
     this.$createPreviewerBubbles('click', 'img-handler');
 
-    this.mermaidFigure = figureElement;
-    this.mermaidTargetFigure = figureElement;
-    if (!this.beginChangeMermaidValue(figureElement)) {
+    if (!this.mermaidSession.beginEdit(figureElement)) {
       return;
     }
 
     const onInvalidTarget = () => this.$removeImgPreviewerBubbles();
-    const validateTarget = () => this.$isImgHandlerValid();
+    const handlerOptions = this.mermaidSession.createHandlerOptions(onInvalidTarget);
 
     const imgSizeDiv = document.createElement('div');
     imgSizeDiv.className = 'cherry-previewer-img-size-handler';
     this.bubble.click.appendChild(imgSizeDiv);
     imgSizeHandler.showBubble(figureElement, imgSizeDiv, this.previewerDom, {
       isMermaid: true,
-      targetIndex: this.mermaidIndex,
-      onInvalidTarget,
-      validateTarget,
+      targetIndex: this.mermaidSession.previewIndex,
+      ...handlerOptions,
     });
-    imgSizeHandler.bindChange(this.changeMermaidSize.bind(this));
+    imgSizeHandler.bindChange((_htmlElement, style) => this.mermaidSession.changeSize(style));
+    this.mermaidSession.bindPositionFollow();
 
     // 添加对齐工具面板（仅对齐按钮，不含装饰按钮）
     const imgToolDiv = document.createElement('div');
@@ -1266,156 +1214,21 @@ export default class PreviewerBubble {
       this.previewerDom,
       event,
       this.previewer.$cherry.getLocales(),
-      { isMermaid: true, targetIndex: this.mermaidIndex, onInvalidTarget, validateTarget },
+      { isMermaid: true, targetIndex: this.mermaidSession.previewIndex, ...handlerOptions },
     );
-    imgToolHandler.bindChange(this.changeMermaidStyle.bind(this));
+    imgToolHandler.bindChange((_htmlElement, type) => this.mermaidSession.changeAlign(type));
 
     const updateHandler = imgSizeHandler.updatePosition.bind(imgSizeHandler);
     this.$cherry.$event.on('editor.size.change', updateHandler);
     const originalRemove = imgSizeHandler.remove;
     imgSizeHandler.remove = () => {
       this.$cherry.$event.off('editor.size.change', updateHandler);
+      this.mermaidSession.disposeHandlers();
       return originalRemove.call(imgSizeHandler);
     };
     this.bubbleHandler.click = imgSizeHandler;
     this.bubbleHandler.imgTool = imgToolHandler;
   }
-
-  /**
-   * 选中 mermaid 代码块语法的语言行中的扩展参数部分（尺寸 + 对齐）
-   * @param {HTMLElement} figureElement mermaid figure DOM
-   * @returns {boolean}
-   */
-  beginChangeMermaidValue(figureElement) {
-    // 找到预览区中所有 mermaid 图表，确定当前点击的是第几个
-    const allMermaidFigures = Array.from(this.previewerDom.querySelectorAll('figure[data-type="mermaid"]'));
-    const mermaidIndex = allMermaidFigures.indexOf(figureElement);
-    if (mermaidIndex < 0) {
-      return false;
-    }
-    this.mermaidIndex = mermaidIndex;
-
-    const rawContent = this.editor.editor.view.state.doc.toString();
-    // 在编辑器原始内容中按顺序找到所有 mermaid 代码块
-    const codeBlockReg = /(?:^|\n)(\n*(?:>[\t ]*)*(?:[^\S\n]*))(`{3,})([^`]*?)\n([\w\W]*?)\n\s*\2[ \t]*(?=$|\n)/g;
-    let match;
-    let currentMermaidIdx = -1;
-
-    while ((match = codeBlockReg.exec(rawContent)) !== null) {
-      const langLine = match[3].trim().toLowerCase();
-      const langPure = langLine
-        .replace(/#([0-9]+(px|em|pt|pc|in|mm|cm|ex|%)|auto)/gi, '')
-        .replace(/#(center|right|left|float-right|float-left)/gi, '')
-        .trim();
-
-      // 判断是否为 mermaid 类型的代码块
-      if (langPure !== 'mermaid' && !/^flow([ ](td|lr))?$/i.test(langPure) && langPure !== 'seq') {
-        continue;
-      }
-      currentMermaidIdx += 1;
-      if (currentMermaidIdx !== mermaidIndex) {
-        continue;
-      }
-
-      // 找到了对应的代码块，定位语言行
-      const fullMatchStart = match.index;
-      const leadingContent = match[1] || '';
-      const backtickPos = rawContent.indexOf(match[2], fullMatchStart + leadingContent.length);
-      const beforeBacktick = rawContent.substring(0, backtickPos);
-      const langLineNum = (beforeBacktick.match(/\n/g) || []).length;
-
-      // 获取该行的完整内容
-      const allLines = rawContent.split('\n');
-      const fullLangLine = allLines[langLineNum] || '';
-
-      // 匹配所有扩展参数（尺寸 + 对齐），如 "#400px #300px #center"
-      const extendRegex =
-        /((?:\s*#(?:[0-9]+(?:px|em|pt|pc|in|mm|cm|ex|%)|auto|center|right|left|float-right|float-left))+)\s*$/i;
-      const extendMatch = fullLangLine.match(extendRegex);
-
-      // 提取当前的尺寸和对齐信息
-      const sizeRegex = /#([0-9]+(?:px|em|pt|pc|in|mm|cm|ex|%)|auto)/gi;
-      const alignRegex = /#(center|right|left|float-right|float-left)/i;
-      const sizeMatches = fullLangLine.match(sizeRegex);
-      const alignMatch = fullLangLine.match(alignRegex);
-
-      this.mermaidSize = sizeMatches ? sizeMatches.join(' ') : '';
-      this.mermaidAlign = alignMatch ? alignMatch[0] : '';
-
-      // CM6: 计算扩展参数的文档偏移量
-      const { doc } = this.editor.editor.view.state;
-      const lineStart = doc.line(langLineNum + 1).from;
-
-      if (extendMatch) {
-        const extendStart = fullLangLine.indexOf(extendMatch[1]);
-        this.mermaidExtendFrom = lineStart + extendStart;
-        this.mermaidExtendTo = this.mermaidExtendFrom + extendMatch[1].length;
-        this.editor.editor.setSelection(this.mermaidExtendFrom, this.mermaidExtendTo);
-      } else {
-        this.mermaidExtendFrom = lineStart + fullLangLine.length;
-        this.mermaidExtendTo = this.mermaidExtendFrom;
-        this.editor.editor.setSelection(this.mermaidExtendFrom, this.mermaidExtendFrom);
-      }
-
-      this.mermaidLangLineNum = langLineNum;
-      this.mermaidHasExtend = !!extendMatch;
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * 拼接 mermaid 扩展参数并替换编辑器中的选中文本
-   */
-  changeMermaidValue() {
-    const value = [this.mermaidSize, this.mermaidAlign].filter((v) => v).join(' ');
-
-    if (this.mermaidHasExtend) {
-      this.editor.editor.setSelection(this.mermaidExtendFrom, this.mermaidExtendTo);
-      this.editor.editor.replaceSelection(value, 'around');
-      this.mermaidExtendTo = this.mermaidExtendFrom + value.length;
-    } else if (value) {
-      this.editor.editor.setSelection(this.mermaidExtendFrom, this.mermaidExtendFrom);
-      this.editor.editor.replaceSelection(` ${value}`, 'around');
-      this.mermaidExtendFrom += 1;
-      this.mermaidExtendTo = this.mermaidExtendFrom + value.length;
-      this.mermaidHasExtend = true;
-    }
-  }
-
-  /**
-   * 修改 mermaid 图表尺寸时的回调
-   * @param {HTMLElement} htmlElement mermaid figure 元素
-   * @param {Object} style 图表的属性（宽高）
-   */
-  changeMermaidSize(htmlElement, style) {
-    this.mermaidSize = `#${Math.round(style.width)}px #${Math.round(style.height)}px`;
-    this.changeMermaidValue();
-  }
-
-  /**
-   * 修改 mermaid 图表对齐方式时的回调
-   * @param {HTMLElement} htmlElement mermaid figure 元素
-   * @param {string} type 对齐方式
-   */
-  changeMermaidStyle(htmlElement, type) {
-    switch (type) {
-      case 'left':
-      case 'right':
-      case 'center':
-      case 'float-left':
-      case 'float-right':
-        this.mermaidAlign = `#${type}`;
-        break;
-      case 'clear-align':
-        this.mermaidAlign = '';
-        break;
-      default:
-        return;
-    }
-    this.changeMermaidValue();
-  }
-
   /**
    * 处理 mermaid 源码/预览切换工具栏的点击
    * @param {Element} tabElement 被点击的 tab 元素

--- a/packages/cherry-markdown/src/utils/imgSizeHandler.js
+++ b/packages/cherry-markdown/src/utils/imgSizeHandler.js
@@ -171,14 +171,15 @@ const imgSizeHandler = {
     if (!this.isMermaid || !this.previewerDom) {
       return;
     }
-    if (this.img && this.previewerDom.contains(this.img)) {
-      return;
-    }
     if (typeof this.resolveTarget === 'function') {
       const resolved = this.resolveTarget();
       if (resolved) {
         this.img = resolved;
+        return;
       }
+    }
+    if (this.img && this.previewerDom.contains(this.img)) {
+      return;
     }
   },
   drawBubbleButs() {

--- a/packages/cherry-markdown/src/utils/imgSizeHandler.js
+++ b/packages/cherry-markdown/src/utils/imgSizeHandler.js
@@ -97,6 +97,7 @@ const imgSizeHandler = {
     this.targetIndex = Number.isInteger(options.targetIndex) ? options.targetIndex : -1;
     this.onInvalidTarget = options.onInvalidTarget || null;
     this.validateTarget = options.validateTarget || null;
+    this.resolveTarget = options.resolveTarget || null;
     this.previewerDom = previewerDom;
     this.container = container;
     this.buts = this.initBubbleButtons();
@@ -167,15 +168,18 @@ const imgSizeHandler = {
     }, 120);
   },
   refreshTarget() {
-    if (!this.isMermaid || this.targetIndex < 0 || !this.previewerDom) {
+    if (!this.isMermaid || !this.previewerDom) {
       return;
     }
-    // 当前目标仍在预览区时保留引用，避免因索引位移误绑到其他 mermaid
     if (this.img && this.previewerDom.contains(this.img)) {
       return;
     }
-    const figures = this.previewerDom.querySelectorAll('figure[data-type="mermaid"]');
-    this.img = figures[this.targetIndex] || this.img;
+    if (typeof this.resolveTarget === 'function') {
+      const resolved = this.resolveTarget();
+      if (resolved) {
+        this.img = resolved;
+      }
+    }
   },
   drawBubbleButs() {
     if (this.butsLayout) {
@@ -203,6 +207,8 @@ const imgSizeHandler = {
     this.butsPoints = null;
     this.onInvalidTarget = null;
     this.validateTarget = null;
+    this.resolveTarget = null;
+    this.onPositionUpdated = null;
   },
   updateBubbleButs() {
     this.$updatePointsInfo();
@@ -214,6 +220,9 @@ const imgSizeHandler = {
       this.butsPoints[`pints-${name}`].style.top = `${this.buts.points.arrInfo[name].top}px`;
       this.butsPoints[`pints-${name}`].style.left = `${this.buts.points.arrInfo[name].left}px`;
     });
+    if (this.isMermaid) {
+      this.onPositionUpdated?.();
+    }
   },
   $updatePointsInfo() {
     const pointLeft = this.buts.style.width;

--- a/packages/cherry-markdown/src/utils/imgSizeHandler.js
+++ b/packages/cherry-markdown/src/utils/imgSizeHandler.js
@@ -95,6 +95,8 @@ const imgSizeHandler = {
     this.img = img;
     this.isMermaid = options.isMermaid || false;
     this.targetIndex = Number.isInteger(options.targetIndex) ? options.targetIndex : -1;
+    this.onInvalidTarget = options.onInvalidTarget || null;
+    this.validateTarget = options.validateTarget || null;
     this.previewerDom = previewerDom;
     this.container = container;
     this.buts = this.initBubbleButtons();
@@ -118,16 +120,38 @@ const imgSizeHandler = {
         requestAnimationFrame(() => this.updatePosition());
     }
   },
+  $isTargetValid() {
+    if (typeof this.validateTarget === 'function') {
+      return this.validateTarget();
+    }
+    return !!(this.img && document.contains(this.img) && this.previewerDom?.contains(this.img));
+  },
+  $clearPreviewUpdateTimer() {
+    if (this._fallbackTimer) {
+      clearTimeout(this._fallbackTimer);
+      this._fallbackTimer = null;
+    }
+  },
   previewUpdate(callback) {
     if (this.$isResizing()) {
       return;
     }
+    this.$clearPreviewUpdateTimer();
     this.refreshTarget();
+    // 目标元素已从预览区移除（如删除了 mermaid 源码），清理选择框和浮动工具栏
+    if (!this.$isTargetValid()) {
+      (callback || this.onInvalidTarget)?.();
+      return;
+    }
     // 预览区更新后图片位置可能变化（如对齐方式改变），需要更新选择框位置
     // 图片有 CSS transition (all 0.1s)，需等待过渡动画结束后再获取最终位置
     this.img.addEventListener(
       'transitionend',
       () => {
+        if (!this.$isTargetValid()) {
+          this.onInvalidTarget?.();
+          return;
+        }
         this.updatePosition();
       },
       { once: true },
@@ -135,11 +159,19 @@ const imgSizeHandler = {
     // 兜底：如果过渡没有触发（如属性没变化），100ms 后也更新
     this._fallbackTimer = setTimeout(() => {
       this._fallbackTimer = null;
+      if (!this.$isTargetValid()) {
+        (callback || this.onInvalidTarget)?.();
+        return;
+      }
       this.updatePosition();
     }, 120);
   },
   refreshTarget() {
     if (!this.isMermaid || this.targetIndex < 0 || !this.previewerDom) {
+      return;
+    }
+    // 当前目标仍在预览区时保留引用，避免因索引位移误绑到其他 mermaid
+    if (this.img && this.previewerDom.contains(this.img)) {
       return;
     }
     const figures = this.previewerDom.querySelectorAll('figure[data-type="mermaid"]');
@@ -166,11 +198,11 @@ const imgSizeHandler = {
     return this.updateBubbleButs();
   },
   remove() {
+    this.$clearPreviewUpdateTimer();
     this.butsLayout = false;
-    if (this._fallbackTimer) {
-      clearTimeout(this._fallbackTimer);
-      this._fallbackTimer = null;
-    }
+    this.butsPoints = null;
+    this.onInvalidTarget = null;
+    this.validateTarget = null;
   },
   updateBubbleButs() {
     this.$updatePointsInfo();
@@ -363,6 +395,10 @@ const imgSizeHandler = {
       return;
     }
     this.refreshTarget();
+    if (!this.$isTargetValid()) {
+      this.onInvalidTarget?.();
+      return;
+    }
     // 重新计算图片位置
     const newPosition = this.getImgPosition();
     this.buts.position = newPosition;

--- a/packages/cherry-markdown/src/utils/imgToolHandler.js
+++ b/packages/cherry-markdown/src/utils/imgToolHandler.js
@@ -241,14 +241,15 @@ const imgToolHandler = {
     if (!this.isMermaid || !this.previewerDom) {
       return;
     }
-    if (this.img && this.previewerDom.contains(this.img)) {
-      return;
-    }
     if (typeof this.resolveTarget === 'function') {
       const resolved = this.resolveTarget();
       if (resolved) {
         this.img = resolved;
+        return;
       }
+    }
+    if (this.img && this.previewerDom.contains(this.img)) {
+      return;
     }
   },
   remove() {

--- a/packages/cherry-markdown/src/utils/imgToolHandler.js
+++ b/packages/cherry-markdown/src/utils/imgToolHandler.js
@@ -38,6 +38,8 @@ const imgToolHandler = {
     this.img = img;
     this.isMermaid = options.isMermaid || false;
     this.targetIndex = Number.isInteger(options.targetIndex) ? options.targetIndex : -1;
+    this.onInvalidTarget = options.onInvalidTarget || null;
+    this.validateTarget = options.validateTarget || null;
 
     this.previewerDom = previewerDom;
     this.container = container;
@@ -183,20 +185,54 @@ const imgToolHandler = {
     switch (type) {
       case 'scroll':
         return this.dealScroll(event);
+      case 'remove':
+        return this.remove();
       case 'previewUpdate':
         return this.previewUpdate(event);
       case 'resize':
         requestAnimationFrame(() => this.updatePosition());
     }
   },
+  $isTargetValid() {
+    if (typeof this.validateTarget === 'function') {
+      return this.validateTarget();
+    }
+    return !!(this.img && document.contains(this.img) && this.previewerDom?.contains(this.img));
+  },
+  $clearPreviewUpdateTimer() {
+    if (this._fallbackTimer) {
+      clearTimeout(this._fallbackTimer);
+      this._fallbackTimer = null;
+    }
+  },
   previewUpdate(callback) {
+    this.$clearPreviewUpdateTimer();
     this.refreshTarget();
+    // 目标元素已从预览区移除（如删除了 mermaid 源码），清理选择框和浮动工具栏
+    if (!this.$isTargetValid()) {
+      (callback || this.onInvalidTarget)?.();
+      return;
+    }
     // 预览区更新后图片位置可能变化（如对齐方式改变），需要更新工具栏位置
     // 图片有 CSS transition (all 0.1s)，需等待过渡动画结束后再获取最终位置
-    this.img.addEventListener('transitionend', () => this.updatePosition(), { once: true });
+    this.img.addEventListener(
+      'transitionend',
+      () => {
+        if (!this.$isTargetValid()) {
+          this.onInvalidTarget?.();
+          return;
+        }
+        this.updatePosition();
+      },
+      { once: true },
+    );
     // 兜底：如果过渡没有触发（如属性没变化），120ms 后也更新
     this._fallbackTimer = setTimeout(() => {
       this._fallbackTimer = null;
+      if (!this.$isTargetValid()) {
+        (callback || this.onInvalidTarget)?.();
+        return;
+      }
       this.updatePosition();
     }, 120);
   },
@@ -204,15 +240,17 @@ const imgToolHandler = {
     if (!this.isMermaid || this.targetIndex < 0 || !this.previewerDom) {
       return;
     }
+    // 当前目标仍在预览区时保留引用，避免因索引位移误绑到其他 mermaid
+    if (this.img && this.previewerDom.contains(this.img)) {
+      return;
+    }
     const figures = this.previewerDom.querySelectorAll('figure[data-type="mermaid"]');
     this.img = figures[this.targetIndex] || this.img;
   },
   remove() {
-    this.butsLayout = false;
-    if (this._fallbackTimer) {
-      clearTimeout(this._fallbackTimer);
-      this._fallbackTimer = null;
-    }
+    this.$clearPreviewUpdateTimer();
+    this.onInvalidTarget = null;
+    this.validateTarget = null;
   },
   /**
    * 更新工具栏位置，用于预览区更新或编辑器大小变化后重新定位
@@ -222,6 +260,10 @@ const imgToolHandler = {
       return;
     }
     this.refreshTarget();
+    if (!this.$isTargetValid()) {
+      this.onInvalidTarget?.();
+      return;
+    }
     const imgPosition = this.getImgPosition();
     const toolbarWidth = this.container.offsetWidth;
     const toolbarHeight = this.container.offsetHeight;

--- a/packages/cherry-markdown/src/utils/imgToolHandler.js
+++ b/packages/cherry-markdown/src/utils/imgToolHandler.js
@@ -40,6 +40,7 @@ const imgToolHandler = {
     this.targetIndex = Number.isInteger(options.targetIndex) ? options.targetIndex : -1;
     this.onInvalidTarget = options.onInvalidTarget || null;
     this.validateTarget = options.validateTarget || null;
+    this.resolveTarget = options.resolveTarget || null;
 
     this.previewerDom = previewerDom;
     this.container = container;
@@ -237,20 +238,24 @@ const imgToolHandler = {
     }, 120);
   },
   refreshTarget() {
-    if (!this.isMermaid || this.targetIndex < 0 || !this.previewerDom) {
+    if (!this.isMermaid || !this.previewerDom) {
       return;
     }
-    // 当前目标仍在预览区时保留引用，避免因索引位移误绑到其他 mermaid
     if (this.img && this.previewerDom.contains(this.img)) {
       return;
     }
-    const figures = this.previewerDom.querySelectorAll('figure[data-type="mermaid"]');
-    this.img = figures[this.targetIndex] || this.img;
+    if (typeof this.resolveTarget === 'function') {
+      const resolved = this.resolveTarget();
+      if (resolved) {
+        this.img = resolved;
+      }
+    }
   },
   remove() {
     this.$clearPreviewUpdateTimer();
     this.onInvalidTarget = null;
     this.validateTarget = null;
+    this.resolveTarget = null;
   },
   /**
    * 更新工具栏位置，用于预览区更新或编辑器大小变化后重新定位

--- a/packages/cherry-markdown/src/utils/mermaidEditorHelper.js
+++ b/packages/cherry-markdown/src/utils/mermaidEditorHelper.js
@@ -132,14 +132,30 @@ export function getMermaidBlockAtPreviewIndex(rawContent, previewIndex) {
  * 按源码内容查找 mermaid 块在编辑器中的 index（删邻居块后 index 会变化）
  * @param {string} rawContent
  * @param {string} codeBody 选中时记录的代码块正文
+ * @param {number} [preferredIndex=-1] 多个块正文相同时，优先命中该 index
  * @returns {number} index，未找到返回 -1
  */
-export function findMermaidBlockIndexByCodeBody(rawContent, codeBody) {
+export function findMermaidBlockIndexByCodeBody(rawContent, codeBody, preferredIndex = -1) {
   if (!codeBody) {
     return -1;
   }
   const blocks = listMermaidBlocks(rawContent);
-  return blocks.findIndex((block) => block.codeBody === codeBody);
+  const matchedIndices = blocks.reduce((indices, block, index) => {
+    if (block.codeBody === codeBody) {
+      indices.push(index);
+    }
+    return indices;
+  }, /** @type {number[]} */ ([]));
+  if (matchedIndices.length === 0) {
+    return -1;
+  }
+  if (matchedIndices.length === 1) {
+    return matchedIndices[0];
+  }
+  if (preferredIndex >= 0 && matchedIndices.includes(preferredIndex)) {
+    return preferredIndex;
+  }
+  return matchedIndices[0];
 }
 
 /**

--- a/packages/cherry-markdown/src/utils/mermaidEditorHelper.js
+++ b/packages/cherry-markdown/src/utils/mermaidEditorHelper.js
@@ -1,0 +1,185 @@
+/**
+ * mermaid 编辑器侧代码块解析
+ *
+ * 职责（维护入口集中在此文件）：
+ * - 识别编辑器中的 mermaid 代码块
+ * - 按源码正文锚定块（删邻居后 rebind）
+ * - 解析语言行上的尺寸/对齐扩展参数
+ */
+
+/** @type {RegExp} 与 PreviewerBubble 历史逻辑保持一致 */
+export const MERMAID_CODE_BLOCK_REG =
+  /(?:^|\n)(\n*(?:>[\t ]*)*(?:[^\S\n]*))(`{3,})([^`]*?)\n([\w\W]*?)\n\s*\2[ \t]*(?=$|\n)/g;
+
+const MERMAID_LAYOUT_EXTEND_REG =
+  /((?:\s*#(?:[0-9]+(?:px|em|pt|pc|in|mm|cm|ex|%)|auto|center|right|left|float-right|float-left))+)\s*$/i;
+const MERMAID_SIZE_REG = /#([0-9]+(?:px|em|pt|pc|in|mm|cm|ex|%)|auto)/gi;
+const MERMAID_ALIGN_REG = /#(center|right|left|float-right|float-left)/i;
+
+/**
+ * 判断语言行是否为 mermaid 类型
+ * @param {string} langLine
+ * @returns {boolean}
+ */
+export function isMermaidLangLine(langLine) {
+  const langPure = langLine
+    .trim()
+    .toLowerCase()
+    .replace(/#([0-9]+(px|em|pt|pc|in|mm|cm|ex|%)|auto)/gi, '')
+    .replace(/#(center|right|left|float-right|float-left)/gi, '')
+    .trim();
+  return langPure === 'mermaid' || /^flow([ ](td|lr))?$/i.test(langPure) || langPure === 'seq';
+}
+
+/**
+ * 解析语言行上的尺寸与对齐扩展参数
+ * @param {string} fullLangLine 语言行完整文本（含反引号后的 lang 部分所在行）
+ * @returns {{
+ *   size: string,
+ *   align: string,
+ *   hasExtend: boolean,
+ *   extendStartInLine: number,
+ *   extendLength: number,
+ * }}
+ */
+export function parseMermaidLayoutFromLangLine(fullLangLine) {
+  const extendMatch = fullLangLine.match(MERMAID_LAYOUT_EXTEND_REG);
+  const sizeMatches = fullLangLine.match(MERMAID_SIZE_REG);
+  const alignMatch = fullLangLine.match(MERMAID_ALIGN_REG);
+
+  if (extendMatch) {
+    return {
+      size: sizeMatches ? sizeMatches.join(' ') : '',
+      align: alignMatch ? alignMatch[0] : '',
+      hasExtend: true,
+      extendStartInLine: fullLangLine.indexOf(extendMatch[1]),
+      extendLength: extendMatch[1].length,
+    };
+  }
+
+  return {
+    size: sizeMatches ? sizeMatches.join(' ') : '',
+    align: alignMatch ? alignMatch[0] : '',
+    hasExtend: false,
+    extendStartInLine: fullLangLine.length,
+    extendLength: 0,
+  };
+}
+
+/**
+ * 列出编辑器中所有 mermaid 代码块
+ * @param {string} rawContent
+ * @returns {{
+ *   index: number,
+ *   codeBody: string,
+ *   langLine: string,
+ *   matchIndex: number,
+ *   leadingContent: string,
+ *   fence: string,
+ * }[]}
+ */
+export function listMermaidBlocks(rawContent) {
+  const blocks = [];
+  if (!rawContent) {
+    return blocks;
+  }
+  const reg = new RegExp(MERMAID_CODE_BLOCK_REG.source, 'g');
+  let match;
+  while ((match = reg.exec(rawContent)) !== null) {
+    const langLine = match[3].trim().toLowerCase();
+    if (!isMermaidLangLine(langLine)) {
+      continue;
+    }
+    blocks.push({
+      index: blocks.length,
+      codeBody: match[4],
+      langLine,
+      matchIndex: match.index,
+      leadingContent: match[1] || '',
+      fence: match[2],
+    });
+  }
+  return blocks;
+}
+
+/**
+ * 计算代码块语言行在文档中的行号（0-based）
+ * @param {string} rawContent
+ * @param {{ matchIndex: number, leadingContent: string, fence: string }} block
+ * @returns {number}
+ */
+export function getMermaidLangLineNumber(rawContent, block) {
+  const backtickPos = rawContent.indexOf(block.fence, block.matchIndex + block.leadingContent.length);
+  const beforeBacktick = rawContent.substring(0, backtickPos);
+  return (beforeBacktick.match(/\n/g) || []).length;
+}
+
+/**
+ * 按预览区 index 获取对应编辑器 mermaid 块
+ * @param {string} rawContent
+ * @param {number} previewIndex
+ * @returns {ReturnType<typeof listMermaidBlocks>[number] | null}
+ */
+export function getMermaidBlockAtPreviewIndex(rawContent, previewIndex) {
+  if (previewIndex < 0) {
+    return null;
+  }
+  const blocks = listMermaidBlocks(rawContent);
+  return blocks[previewIndex] || null;
+}
+
+/**
+ * 按源码内容查找 mermaid 块在编辑器中的 index（删邻居块后 index 会变化）
+ * @param {string} rawContent
+ * @param {string} codeBody 选中时记录的代码块正文
+ * @returns {number} index，未找到返回 -1
+ */
+export function findMermaidBlockIndexByCodeBody(rawContent, codeBody) {
+  if (!codeBody) {
+    return -1;
+  }
+  const blocks = listMermaidBlocks(rawContent);
+  return blocks.findIndex((block) => block.codeBody === codeBody);
+}
+
+/**
+ * 构建 mermaid 布局编辑所需的编辑器选区信息
+ * @param {string} rawContent
+ * @param {number} previewIndex 预览区 figure index
+ * @param {import('@codemirror/state').Text} doc CM6 文档
+ * @returns {{
+ *   previewIndex: number,
+ *   anchorBody: string,
+ *   langLineNum: number,
+ *   extendFrom: number,
+ *   extendTo: number,
+ *   size: string,
+ *   align: string,
+ *   hasExtend: boolean,
+ * } | null}
+ */
+export function buildMermaidEditContext(rawContent, previewIndex, doc) {
+  const block = getMermaidBlockAtPreviewIndex(rawContent, previewIndex);
+  if (!block || !doc) {
+    return null;
+  }
+
+  const langLineNum = getMermaidLangLineNumber(rawContent, block);
+  const fullLangLine = rawContent.split('\n')[langLineNum] || '';
+  const layout = parseMermaidLayoutFromLangLine(fullLangLine);
+  const lineStart = doc.line(langLineNum + 1).from;
+
+  const extendFrom = lineStart + layout.extendStartInLine;
+  const extendTo = layout.hasExtend ? extendFrom + layout.extendLength : extendFrom;
+
+  return {
+    previewIndex,
+    anchorBody: block.codeBody,
+    langLineNum,
+    extendFrom,
+    extendTo,
+    size: layout.size,
+    align: layout.align,
+    hasExtend: layout.hasExtend,
+  };
+}

--- a/packages/cherry-markdown/src/utils/mermaidPreviewHelper.js
+++ b/packages/cherry-markdown/src/utils/mermaidPreviewHelper.js
@@ -1,0 +1,81 @@
+/**
+ * mermaid 预览可见性判断
+ * 用于决定右侧尺寸编辑框是否应继续展示（figure 壳子可能还在，但预览图表已消失）
+ */
+
+/**
+ * 获取 mermaid 预览内容根节点（工具栏模式下为 preview panel，否则为 figure 本身）
+ * @param {HTMLElement} figure
+ * @returns {HTMLElement}
+ */
+export function getMermaidPreviewRoot(figure) {
+  const previewPanel = figure.querySelector('.cherry-mermaid-source-toolbar-panel[data-mode="preview"]');
+  return /** @type {HTMLElement} */ (previewPanel || figure);
+}
+
+/**
+ * 获取 mermaid 渲染后的可视节点（svg 或 svg 转 img）
+ * @param {ParentNode} root
+ * @returns {Element | null}
+ */
+export function getMermaidVisualElement(root) {
+  const svg = root.querySelector('svg');
+  if (svg) {
+    return svg;
+  }
+  const svgImg = root.querySelector('img.svg-img');
+  return svgImg || null;
+}
+
+/**
+ * 读取元素可视尺寸（优先 layout，回退 attribute）
+ * @param {Element} visual
+ * @returns {{ width: number, height: number }}
+ */
+function getVisualSize(visual) {
+  const htmlVisual = /** @type {HTMLElement} */ (visual);
+  const rect = htmlVisual.getBoundingClientRect();
+  if (rect.width > 0 && rect.height > 0) {
+    return { width: rect.width, height: rect.height };
+  }
+  const width =
+    htmlVisual.offsetWidth || Number.parseFloat(htmlVisual.getAttribute('width') || '') || 0;
+  const height =
+    htmlVisual.offsetHeight || Number.parseFloat(htmlVisual.getAttribute('height') || '') || 0;
+  return { width, height };
+}
+
+/**
+ * 预览区内是否存在已渲染且可见的 mermaid 图表
+ * @param {ParentNode} root
+ * @returns {boolean}
+ */
+export function hasMermaidRenderedContent(root) {
+  const visual = getMermaidVisualElement(root);
+  if (!visual) {
+    return false;
+  }
+  const { width, height } = getVisualSize(visual);
+  return width > 0 && height > 0;
+}
+
+/**
+ * 判断 mermaid 预览是否仍可用于尺寸/对齐编辑
+ * @param {HTMLElement | null | undefined} figure
+ * @param {ParentNode | null | undefined} previewerDom
+ * @returns {boolean}
+ */
+export function isMermaidPreviewVisible(figure, previewerDom) {
+  if (!figure || !previewerDom || !document.contains(figure) || !previewerDom.contains(figure)) {
+    return false;
+  }
+  if (figure.getAttribute('data-type') !== 'mermaid') {
+    return false;
+  }
+  // 工具栏切到源码模式时不展示尺寸编辑框
+  if (figure.querySelector('.cherry-mermaid-source-toolbar-panel.active[data-mode="source"]')) {
+    return false;
+  }
+  const previewRoot = getMermaidPreviewRoot(figure);
+  return hasMermaidRenderedContent(previewRoot);
+}

--- a/packages/cherry-markdown/src/utils/mermaidPreviewHelper.js
+++ b/packages/cherry-markdown/src/utils/mermaidPreviewHelper.js
@@ -68,10 +68,8 @@ function getVisualSize(visual) {
   if (rect.width > 0 && rect.height > 0) {
     return { width: rect.width, height: rect.height };
   }
-  const width =
-    htmlVisual.offsetWidth || Number.parseFloat(htmlVisual.getAttribute('width') || '') || 0;
-  const height =
-    htmlVisual.offsetHeight || Number.parseFloat(htmlVisual.getAttribute('height') || '') || 0;
+  const width = htmlVisual.offsetWidth || Number.parseFloat(htmlVisual.getAttribute('width') || '') || 0;
+  const height = htmlVisual.offsetHeight || Number.parseFloat(htmlVisual.getAttribute('height') || '') || 0;
   return { width, height };
 }
 

--- a/packages/cherry-markdown/src/utils/mermaidPreviewHelper.js
+++ b/packages/cherry-markdown/src/utils/mermaidPreviewHelper.js
@@ -4,6 +4,36 @@
  */
 
 /**
+ * 统计预览区 mermaid figure 数量
+ * @param {ParentNode} previewerDom
+ * @returns {number}
+ */
+export function countMermaidFigures(previewerDom) {
+  if (!previewerDom) {
+    return 0;
+  }
+  return previewerDom.querySelectorAll('figure[data-type="mermaid"]').length;
+}
+
+/**
+ * 按 index 解析 mermaid figure
+ * @param {ParentNode} previewerDom
+ * @param {number} index
+ * @param {number} [expectedFigureCount=-1] 传入时须与当前 figure 数量一致，-1 表示不校验
+ * @returns {HTMLElement | null}
+ */
+export function getMermaidFigureByIndex(previewerDom, index, expectedFigureCount = -1) {
+  if (!previewerDom || index < 0) {
+    return null;
+  }
+  const figures = previewerDom.querySelectorAll('figure[data-type="mermaid"]');
+  if (expectedFigureCount >= 0 && figures.length !== expectedFigureCount) {
+    return null;
+  }
+  return /** @type {HTMLElement | null} */ (figures[index] || null);
+}
+
+/**
  * 获取 mermaid 预览内容根节点（工具栏模式下为 preview panel，否则为 figure 本身）
  * @param {HTMLElement} figure
  * @returns {HTMLElement}

--- a/packages/cherry-markdown/test/codemirror/PreviewerBubble.spec.ts
+++ b/packages/cherry-markdown/test/codemirror/PreviewerBubble.spec.ts
@@ -10,6 +10,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import imgSizeHandler from '@/utils/imgSizeHandler';
+import imgToolHandler from '@/utils/imgToolHandler';
 
 // ============ 辅助函数 ============
 
@@ -685,6 +687,25 @@ describe('imgSizeHandler previewUpdate', () => {
   });
 });
 
+describe('imgSizeHandler 目标元素移除', () => {
+  it('previewUpdate 在目标已脱离预览区时应调用清理回调', () => {
+    const previewerDom = document.createElement('div');
+    const removedFigure = document.createElement('figure');
+    removedFigure.setAttribute('data-type', 'mermaid');
+    const callback = vi.fn();
+
+    imgSizeHandler.isMermaid = true;
+    imgSizeHandler.targetIndex = 0;
+    imgSizeHandler.previewerDom = previewerDom;
+    imgSizeHandler.img = removedFigure;
+    imgSizeHandler.mouseResize = { resize: false };
+
+    imgSizeHandler.previewUpdate(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('imgToolHandler previewUpdate', () => {
   let handler: ReturnType<typeof createMockToolHandler>;
 
@@ -809,5 +830,23 @@ describe('imgToolHandler previewUpdate', () => {
       expect.any(Function),
       { once: true },
     );
+  });
+});
+
+describe('imgToolHandler 目标元素移除', () => {
+  it('previewUpdate 在目标已脱离预览区时应调用清理回调', () => {
+    const previewerDom = document.createElement('div');
+    const removedFigure = document.createElement('figure');
+    removedFigure.setAttribute('data-type', 'mermaid');
+    const callback = vi.fn();
+
+    imgToolHandler.isMermaid = true;
+    imgToolHandler.targetIndex = 0;
+    imgToolHandler.previewerDom = previewerDom;
+    imgToolHandler.img = removedFigure;
+
+    imgToolHandler.previewUpdate(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cherry-markdown/test/toolbars/MermaidBubbleSession.spec.ts
+++ b/packages/cherry-markdown/test/toolbars/MermaidBubbleSession.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * MermaidBubbleSession 单元测试
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Text } from '@codemirror/state';
+import imgSizeHandler from '@/utils/imgSizeHandler';
+import imgToolHandler from '@/utils/imgToolHandler';
+import MermaidBubbleSession from '@/toolbars/MermaidBubbleSession';
+
+function createFigure(svgSize = { width: 100, height: 80 }) {
+  const figure = document.createElement('figure');
+  figure.setAttribute('data-type', 'mermaid');
+  const svg = document.createElement('svg');
+  svg.setAttribute('width', String(svgSize.width));
+  svg.setAttribute('height', String(svgSize.height));
+  Object.defineProperty(svg, 'getBoundingClientRect', {
+    value: () => ({
+      width: svgSize.width,
+      height: svgSize.height,
+      top: 0,
+      left: 0,
+      right: svgSize.width,
+      bottom: svgSize.height,
+      x: 0,
+      y: 0,
+    }),
+  });
+  figure.appendChild(svg);
+  return figure;
+}
+
+function createHost(previewerDom: HTMLDivElement, md: string) {
+  const doc = Text.of(md.split('\n'));
+  return {
+    previewerDom,
+    editor: {
+      editor: {
+        view: { state: { doc } },
+        setSelection: vi.fn(),
+        replaceSelection: vi.fn(),
+      },
+    },
+    bubbleHandler: { click: imgSizeHandler, imgTool: imgToolHandler },
+    $removeImgPreviewerBubbles: vi.fn(),
+    $checkAndRemoveInvalidImgHandlers: vi.fn(),
+  };
+}
+
+describe('MermaidBubbleSession', () => {
+  let previewerDom: HTMLDivElement;
+
+  beforeEach(() => {
+    previewerDom = document.createElement('div');
+    document.body.appendChild(previewerDom);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    previewerDom.remove();
+    imgSizeHandler.isMermaid = false;
+    imgSizeHandler.img = null;
+    imgSizeHandler.onInvalidTarget = null;
+    imgSizeHandler.validateTarget = null;
+    imgSizeHandler.resolveTarget = null;
+    vi.useRealTimers();
+  });
+
+  it('邻居异步恢复后应延迟校验，避免上方布局重排误关选中框', () => {
+    const blockA = 'graph TD\n  A-->B';
+    const blockB = 'graph TD\n  C-->D';
+    const md = `\`\`\`mermaid\n${blockA}\n\`\`\`\n\n\`\`\`mermaid\n${blockB}\n\`\`\``;
+
+    const fig0 = createFigure();
+    const fig1 = createFigure();
+    previewerDom.appendChild(fig0);
+    previewerDom.appendChild(fig1);
+
+    const host = createHost(previewerDom, md);
+    const session = new MermaidBubbleSession(host as any);
+
+    imgSizeHandler.isMermaid = true;
+    imgSizeHandler.img = fig1;
+    host.bubbleHandler.click = imgSizeHandler;
+
+    session.beginEdit(fig1);
+
+    let strictVisible = true;
+    const isValidSpy = vi.spyOn(session, 'isValid').mockImplementation((options = {}) => {
+      if (options.strict) {
+        return strictVisible;
+      }
+      return true;
+    });
+
+    session.onAsyncRenderDone();
+
+    expect(host.$checkAndRemoveInvalidImgHandlers).not.toHaveBeenCalled();
+
+    strictVisible = true;
+    vi.advanceTimersByTime(200);
+
+    expect(isValidSpy).toHaveBeenCalled();
+    expect(host.$checkAndRemoveInvalidImgHandlers).not.toHaveBeenCalled();
+  });
+
+  it('延迟校验仍失败时应移除操作框', () => {
+    const blockB = 'graph TD\n  C-->D';
+    const md = `\`\`\`mermaid\ngraph TD\n  A-->B\n\`\`\`\n\n\`\`\`mermaid\n${blockB}\n\`\`\``;
+
+    const fig0 = createFigure();
+    const fig1 = createFigure();
+    previewerDom.appendChild(fig0);
+    previewerDom.appendChild(fig1);
+
+    const host = createHost(previewerDom, md);
+    const session = new MermaidBubbleSession(host as any);
+
+    imgSizeHandler.isMermaid = true;
+    imgSizeHandler.img = fig1;
+    host.bubbleHandler.click = imgSizeHandler;
+
+    session.beginEdit(fig1);
+    vi.spyOn(session, 'isValid').mockReturnValue(false);
+
+    session.onAsyncRenderDone();
+    vi.advanceTimersByTime(500);
+
+    expect(host.$checkAndRemoveInvalidImgHandlers).toHaveBeenCalledWith({ strict: true });
+  });
+});

--- a/packages/cherry-markdown/test/tsconfig.json
+++ b/packages/cherry-markdown/test/tsconfig.json
@@ -9,6 +9,7 @@
       "@/*": ["src/*"],
       "~types/*": ["types/*"]
     },
+    "ignoreDeprecations": "6.0"
   },
   "include": ["./**/*.ts", "./**/*.tsx"],
   "files": ["../types/env.d.ts", "../types/codemirror.d.ts"]

--- a/packages/cherry-markdown/test/tsconfig.json
+++ b/packages/cherry-markdown/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true,
+    "strict": false,
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["src/*"],
+      "~types/*": ["types/*"]
+    },
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"],
+  "files": ["../types/env.d.ts", "../types/codemirror.d.ts"]
+}

--- a/packages/cherry-markdown/test/tsconfig.test.json
+++ b/packages/cherry-markdown/test/tsconfig.test.json
@@ -1,6 +1,0 @@
-{
-    "extends": "../tsconfig.json",
-    "ts-node": {
-        "transpileOnly": true
-    }
-}

--- a/packages/cherry-markdown/test/utils/mermaidEditorHelper.spec.ts
+++ b/packages/cherry-markdown/test/utils/mermaidEditorHelper.spec.ts
@@ -52,6 +52,15 @@ graph TD
     expect(findMermaidBlockIndexByCodeBody(md, blockB)).toBe(-1);
   });
 
+  it('正文相同块应优先命中 anchorPreviewIndex', () => {
+    const body = 'graph TD\n  A-->B';
+    const md = `\`\`\`mermaid\n${body}\n\`\`\`\n\n\`\`\`mermaid\n${body}\n\`\`\``;
+
+    expect(findMermaidBlockIndexByCodeBody(md, body, 0)).toBe(0);
+    expect(findMermaidBlockIndexByCodeBody(md, body, 1)).toBe(1);
+    expect(findMermaidBlockIndexByCodeBody(md, body)).toBe(0);
+  });
+
   it('应解析语言行上的尺寸与对齐扩展参数', () => {
     const layout = parseMermaidLayoutFromLangLine('```mermaid #400px #300px #center');
     expect(layout.size).toBe('#400px #300px');

--- a/packages/cherry-markdown/test/utils/mermaidEditorHelper.spec.ts
+++ b/packages/cherry-markdown/test/utils/mermaidEditorHelper.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * mermaid 编辑器侧锚点逻辑测试
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Text } from '@codemirror/state';
+import {
+  buildMermaidEditContext,
+  findMermaidBlockIndexByCodeBody,
+  isMermaidLangLine,
+  listMermaidBlocks,
+  parseMermaidLayoutFromLangLine,
+} from '@/utils/mermaidEditorHelper';
+
+describe('mermaidEditorHelper', () => {
+  it('应识别 mermaid 语言行', () => {
+    expect(isMermaidLangLine('mermaid #400px #center')).toBe(true);
+    expect(isMermaidLangLine('javascript')).toBe(false);
+  });
+
+  it('应按顺序列出 mermaid 块', () => {
+    const md = `\`\`\`mermaid
+graph TD
+  A-->B
+\`\`\`
+
+\`\`\`mermaid #center
+graph TD
+  C-->D
+\`\`\``;
+
+    const blocks = listMermaidBlocks(md);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].codeBody).toContain('A-->B');
+    expect(blocks[1].codeBody).toContain('C-->D');
+  });
+
+  it('删上方邻居后应按源码锚点找到新 index', () => {
+    const blockA = 'graph TD\n  A-->B';
+    const blockB = 'graph TD\n  C-->D';
+    const mdWithTwo = `\`\`\`mermaid\n${blockA}\n\`\`\`\n\n\`\`\`mermaid\n${blockB}\n\`\`\``;
+    const mdWithOne = `\`\`\`mermaid\n${blockB}\n\`\`\``;
+
+    expect(findMermaidBlockIndexByCodeBody(mdWithTwo, blockB)).toBe(1);
+    expect(findMermaidBlockIndexByCodeBody(mdWithOne, blockB)).toBe(0);
+  });
+
+  it('删除选中块后应找不到锚点', () => {
+    const blockB = 'graph TD\n  C-->D';
+    const md = `\`\`\`mermaid\ngraph TD\n  A-->B\n\`\`\``;
+
+    expect(findMermaidBlockIndexByCodeBody(md, blockB)).toBe(-1);
+  });
+
+  it('应解析语言行上的尺寸与对齐扩展参数', () => {
+    const layout = parseMermaidLayoutFromLangLine('```mermaid #400px #300px #center');
+    expect(layout.size).toBe('#400px #300px');
+    expect(layout.align).toBe('#center');
+    expect(layout.hasExtend).toBe(true);
+    expect(layout.extendLength).toBeGreaterThan(0);
+  });
+
+  it('应构建 mermaid 布局编辑上下文', () => {
+    const md = `\`\`\`mermaid #400px #center
+graph TD
+  A-->B
+\`\`\``;
+    const doc = Text.of(md.split('\n'));
+    const ctx = buildMermaidEditContext(md, 0, doc);
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.anchorBody).toContain('A-->B');
+    expect(ctx?.size).toBe('#400px');
+    expect(ctx?.align).toBe('#center');
+    expect(ctx?.hasExtend).toBe(true);
+    expect(ctx?.extendFrom).toBeLessThan(ctx?.extendTo ?? 0);
+  });
+});

--- a/packages/cherry-markdown/test/utils/mermaidPreviewHelper.spec.ts
+++ b/packages/cherry-markdown/test/utils/mermaidPreviewHelper.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * mermaid 预览可见性判断单元测试
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getMermaidPreviewRoot,
+  hasMermaidRenderedContent,
+  isMermaidPreviewVisible,
+} from '@/utils/mermaidPreviewHelper';
+
+describe('mermaidPreviewHelper', () => {
+  let previewerDom: HTMLDivElement;
+
+  beforeEach(() => {
+    previewerDom = document.createElement('div');
+    document.body.appendChild(previewerDom);
+  });
+
+  afterEach(() => {
+    previewerDom.remove();
+  });
+
+  it('figure 内含 svg 时应判定预览可见', () => {
+    const figure = document.createElement('figure');
+    figure.setAttribute('data-type', 'mermaid');
+    figure.innerHTML = '<svg width="100" height="80"></svg>';
+    previewerDom.appendChild(figure);
+
+    expect(isMermaidPreviewVisible(figure, previewerDom)).toBe(true);
+  });
+
+  it('figure 内含 svg-img 时应判定预览可见', () => {
+    const figure = document.createElement('figure');
+    figure.setAttribute('data-type', 'mermaid');
+    figure.innerHTML = '<img class="svg-img" width="100" height="80" src="data:image/svg+xml," />';
+    previewerDom.appendChild(figure);
+
+    expect(isMermaidPreviewVisible(figure, previewerDom)).toBe(true);
+  });
+
+  it('渲染失败回退为 codeBlock 时应判定预览不可见', () => {
+    const figure = document.createElement('figure');
+    figure.setAttribute('data-type', 'mermaid');
+    figure.innerHTML = '<div data-type="codeBlock"><pre>graph TD\n  A-->B</pre></div>';
+    previewerDom.appendChild(figure);
+
+    expect(isMermaidPreviewVisible(figure, previewerDom)).toBe(false);
+  });
+
+  it('figure 被移出预览区时应判定不可见', () => {
+    const figure = document.createElement('figure');
+    figure.setAttribute('data-type', 'mermaid');
+    figure.innerHTML = '<svg width="100" height="80"></svg>';
+
+    expect(isMermaidPreviewVisible(figure, previewerDom)).toBe(false);
+  });
+
+  it('工具栏切到源码模式时应判定不可见', () => {
+    const figure = document.createElement('figure');
+    figure.setAttribute('data-type', 'mermaid');
+    figure.innerHTML = `
+      <div class="cherry-mermaid-source-toolbar-panel" data-mode="preview">
+        <svg width="100" height="80"></svg>
+      </div>
+      <div class="cherry-mermaid-source-toolbar-panel active" data-mode="source">
+        <div data-type="codeBlock"></div>
+      </div>
+    `;
+    previewerDom.appendChild(figure);
+
+    expect(getMermaidPreviewRoot(figure).getAttribute('data-mode')).toBe('preview');
+    expect(isMermaidPreviewVisible(figure, previewerDom)).toBe(false);
+  });
+
+  it('工具栏 preview panel 内无 svg 时应判定不可见', () => {
+    const figure = document.createElement('figure');
+    figure.setAttribute('data-type', 'mermaid');
+    figure.innerHTML = `
+      <div class="cherry-mermaid-source-toolbar-panel active" data-mode="preview">
+        <div data-type="codeBlock"><pre>broken</pre></div>
+      </div>
+    `;
+    previewerDom.appendChild(figure);
+
+    expect(hasMermaidRenderedContent(getMermaidPreviewRoot(figure))).toBe(false);
+    expect(isMermaidPreviewVisible(figure, previewerDom)).toBe(false);
+  });
+});

--- a/packages/cherry-markdown/test/utils/mermaidPreviewHelper.spec.ts
+++ b/packages/cherry-markdown/test/utils/mermaidPreviewHelper.spec.ts
@@ -1,9 +1,11 @@
 /**
- * mermaid 预览可见性判断单元测试
+ * mermaid 预览辅助逻辑单元测试
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
+  countMermaidFigures,
+  getMermaidFigureByIndex,
   getMermaidPreviewRoot,
   hasMermaidRenderedContent,
   isMermaidPreviewVisible,
@@ -85,5 +87,64 @@ describe('mermaidPreviewHelper', () => {
 
     expect(hasMermaidRenderedContent(getMermaidPreviewRoot(figure))).toBe(false);
     expect(isMermaidPreviewVisible(figure, previewerDom)).toBe(false);
+  });
+});
+
+describe('getMermaidFigureByIndex', () => {
+  let previewerDom: HTMLDivElement;
+
+  beforeEach(() => {
+    previewerDom = document.createElement('div');
+    document.body.appendChild(previewerDom);
+  });
+
+  afterEach(() => {
+    previewerDom.remove();
+  });
+
+  it('应按 index 找到 figure', () => {
+    const fig1 = document.createElement('figure');
+    fig1.setAttribute('data-type', 'mermaid');
+    const fig2 = document.createElement('figure');
+    fig2.setAttribute('data-type', 'mermaid');
+    previewerDom.appendChild(fig1);
+    previewerDom.appendChild(fig2);
+
+    expect(getMermaidFigureByIndex(previewerDom, 0, 2)).toBe(fig1);
+    expect(getMermaidFigureByIndex(previewerDom, 1, 2)).toBe(fig2);
+  });
+
+  it('删除选中块后 figure 数量变化应返回 null', () => {
+    const fig1 = document.createElement('figure');
+    fig1.setAttribute('data-type', 'mermaid');
+    const fig2 = document.createElement('figure');
+    fig2.setAttribute('data-type', 'mermaid');
+    previewerDom.appendChild(fig1);
+    previewerDom.appendChild(fig2);
+
+    fig1.remove();
+
+    expect(getMermaidFigureByIndex(previewerDom, 0, 2)).toBeNull();
+    expect(countMermaidFigures(previewerDom)).toBe(1);
+  });
+
+  it('figure 数量不变时布局刷新后仍可按 index 命中', () => {
+    const fig = document.createElement('figure');
+    fig.setAttribute('data-type', 'mermaid');
+    previewerDom.appendChild(fig);
+
+    expect(getMermaidFigureByIndex(previewerDom, 0, 1)).toBe(fig);
+  });
+
+  it('传入 expectedFigureCount 且数量不一致时返回 null', () => {
+    const fig = document.createElement('figure');
+    fig.setAttribute('data-type', 'mermaid');
+    previewerDom.appendChild(fig);
+
+    const neighbor = document.createElement('figure');
+    neighbor.setAttribute('data-type', 'mermaid');
+    previewerDom.appendChild(neighbor);
+
+    expect(getMermaidFigureByIndex(previewerDom, 0, 1)).toBeNull();
   });
 });


### PR DESCRIPTION
复现步骤
1. 点击右侧预览区的 mermaid 效果图，出现选中框。
2. 编辑左侧编辑区内的 mermaid 代码，破坏 mermaid 渲染。
3. 选中框漂移到左上角，依然依然渲染。

---

预期
mermaid svg 不渲染时，选中框也被移除。