### PR TITLE
fix(editor): 修复从VS Code复制粘贴后光标停留在内容开头

### DIFF
--- a/.changeset/fix-paste-cursor-position.md
+++ b/.changeset/fix-paste-cursor-position.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix(editor): 修复从 VS Code 复制粘贴后光标停留在内容开头

--- a/packages/cherry-markdown/src/Editor.js
+++ b/packages/cherry-markdown/src/Editor.js
@@ -1558,6 +1558,9 @@ export default class Editor {
           to,
           insert: mdText,
         },
+        selection: {
+          anchor: from + mdText.length,
+        },
       });
 
       pasteHelper.showSwitchBtnAfterPasteHtml(this.$cherry, currentCursor, editorView, htmlText, mdText);

--- a/packages/cherry-markdown/test/codemirror/PasteCursor.spec.ts
+++ b/packages/cherry-markdown/test/codemirror/PasteCursor.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * HTML paste cursor regression tests.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Editor from '../../src/Editor';
+import pasteHelper from '../../src/utils/pasteHelper';
+import { createCm6View, getDoc, getSelection } from '../helpers/cM6View';
+
+describe('HTML paste cursor position', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('moves the cursor to the end of converted Markdown', () => {
+    const view = createCm6View('AAABBB', 3);
+    vi.spyOn(pasteHelper, 'showSwitchBtnAfterPasteHtml').mockImplementation(() => {});
+
+    const editor = Object.create(Editor.prototype);
+    editor.$cherry = {};
+
+    editor.formatHtml2MdWhenPaste(null, '<span>PASTED</span>', 'PASTED', view);
+
+    expect(getDoc(view)).toBe('AAAPASTEDBBB');
+    expect(getSelection(view)).toEqual({ anchor: 9, head: 9 });
+
+    view.destroy();
+  });
+
+  it('places the cursor after content that replaces a selection', () => {
+    const view = createCm6View('AAA-old-BBB', 4, 7);
+    vi.spyOn(pasteHelper, 'showSwitchBtnAfterPasteHtml').mockImplementation(() => {});
+
+    const editor = Object.create(Editor.prototype);
+    editor.$cherry = {};
+
+    editor.formatHtml2MdWhenPaste(null, '<strong>NEW</strong>', 'NEW', view);
+
+    expect(getDoc(view)).toBe('AAA-**NEW**-BBB');
+    expect(getSelection(view)).toEqual({ anchor: 11, head: 11 });
+
+    view.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1768

修复从 VS Code 编辑器复制内容后，粘贴到 Cherry 编辑器时光标停留在粘贴内容开头的问题。

## Cause

VS Code 复制内容时会同时提供 `text/plain` 和 `text/html`。Cherry 在处理 HTML 粘贴并转换为 Markdown 后，只更新了文本内容，没有同步更新 CodeMirror 的选区，导致光标保留在粘贴起点。

## Changes

- 在 HTML 转 Markdown 的粘贴事务中，显式将光标移动到插入内容末尾
- 新增回归测试，覆盖：
  - 光标处普通粘贴
  - 替换选中文本后粘贴

## Test

- `yarn workspace cherry-markdown vitest run test/codemirror/PasteCursor.spec.ts test/utils/pasteHelper.spec.ts --coverage.enabled=false`
- 手动验证：从 VS Code 复制代码粘贴后继续输入，内容会出现在粘贴内容末尾