### PR TITLE
fix: avoid `window.Cherry` side effects in ESM bundles

### DIFF
--- a/.changeset/clean-esm-globals.md
+++ b/.changeset/clean-esm-globals.md
@@ -1,0 +1,7 @@
+---
+'cherry-markdown': patch
+---
+
+fix: avoid `window.Cherry` side effects in ESM bundles
+
+拆分 full、core、stream 的 ESM 与 UMD/CDN 入口：ESM 产物不再挂载 `window.Cherry`，UMD/CDN 产物继续挂载并保持原 CDN 路径不变。

--- a/packages/cherry-markdown/build/build.js
+++ b/packages/cherry-markdown/build/build.js
@@ -28,35 +28,43 @@ const terserPlugin = (options = {}) =>
     ...options,
   });
 
-export default {
+const umdOptions = {
   ...baseConfig,
   // 禁用 tree-shaking，保持最大兼容性
   treeshake: false,
-  output: [
-    {
-      ...baseConfig.output,
-      exports: 'named',
-      file: 'dist/cherry-markdown.js',
-      format: 'umd',
-      name: 'Cherry',
-      sourcemap: true,
-      compact: false,
-      inlineDynamicImports: true, // 禁用代码分割，强制内联所有动态导入
-    },
-    {
-      exports: 'named',
-      file: 'dist/cherry-markdown.esm.js',
-      format: 'esm',
-      name: 'Cherry',
-      sourcemap: false,
-      compact: true,
-      inlineDynamicImports: true, // 禁用代码分割，强制内联所有动态导入
-      plugins: [
-        terserPlugin({
-          module: true,
-          ecma: 2015,
-        }),
-      ],
-    },
-  ],
+  input: 'src/index.umd.js',
+  output: {
+    ...baseConfig.output,
+    exports: 'named',
+    file: 'dist/cherry-markdown.js',
+    format: 'umd',
+    name: 'Cherry',
+    sourcemap: true,
+    compact: false,
+    inlineDynamicImports: true, // 禁用代码分割，强制内联所有动态导入
+  },
 };
+
+const esmOptions = {
+  ...baseConfig,
+  // 禁用 tree-shaking，保持最大兼容性
+  treeshake: false,
+  input: 'src/index.js',
+  output: {
+    exports: 'named',
+    file: 'dist/cherry-markdown.esm.js',
+    format: 'esm',
+    name: 'Cherry',
+    sourcemap: false,
+    compact: true,
+    inlineDynamicImports: true, // 禁用代码分割，强制内联所有动态导入
+    plugins: [
+      terserPlugin({
+        module: true,
+        ecma: 2015,
+      }),
+    ],
+  },
+};
+
+export default [umdOptions, esmOptions];

--- a/packages/cherry-markdown/build/rollup.core.config.js
+++ b/packages/cherry-markdown/build/rollup.core.config.js
@@ -28,11 +28,17 @@ const terserPlugin = (options = {}) =>
     ...options,
   });
 
+const sharedExternal = [
+  ...(Array.isArray(baseConfig.external) ? baseConfig.external : []),
+  'mermaid',
+  '@replit/codemirror-vim', // 保持 vim 模块懒加载，避免 code-splitting
+];
+
 const options = {
   ...baseConfig,
   // 禁用 tree-shaking，保持最大兼容性
   treeshake: false,
-  input: 'src/index.core.js',
+  input: 'src/index.core.umd.js',
   output: {
     ...baseConfig.output,
     exports: 'named',
@@ -45,12 +51,7 @@ const options = {
     manualChunks: undefined, // UMD 单文件输出不需要代码分割
   },
   plugins: baseConfig.plugins || [],
+  external: sharedExternal,
 };
-
-if (!Array.isArray(options.external)) {
-  options.external = [];
-}
-options.external.push('mermaid');
-options.external.push('@replit/codemirror-vim'); // 保持 vim 模块懒加载，避免 code-splitting
 
 export default options;

--- a/packages/cherry-markdown/build/rollup.stream.config.js
+++ b/packages/cherry-markdown/build/rollup.stream.config.js
@@ -58,21 +58,31 @@ const esmOutputConfig = {
   ],
 };
 
-const options = {
-  ...baseConfig,
-  // 禁用 tree-shaking，保持最大兼容性
-  treeshake: false,
-  input: 'src/index.stream.js',
-  output: [umdOutputConfig, esmOutputConfig],
-  plugins: baseConfig.plugins || [],
-};
-
-// 合并 external 配置：保留 baseConfig 的 external（jsdom），并添加 stream 特有的
-options.external = [
+const sharedExternal = [
   ...(Array.isArray(baseConfig.external) ? baseConfig.external : []),
   'mermaid',
   'codemirror',
   /^codemirror\/.*/, // 排除所有codemirror子模块
 ];
 
-export default options;
+const umdOptions = {
+  ...baseConfig,
+  // 禁用 tree-shaking，保持最大兼容性
+  treeshake: false,
+  input: 'src/index.stream.umd.js',
+  output: umdOutputConfig,
+  plugins: baseConfig.plugins || [],
+  external: sharedExternal,
+};
+
+const esmOptions = {
+  ...baseConfig,
+  // 禁用 tree-shaking，保持最大兼容性
+  treeshake: false,
+  input: 'src/index.stream.js',
+  output: esmOutputConfig,
+  plugins: baseConfig.plugins || [],
+  external: sharedExternal,
+};
+
+export default [umdOptions, esmOptions];

--- a/packages/cherry-markdown/src/index.core.js
+++ b/packages/cherry-markdown/src/index.core.js
@@ -17,12 +17,6 @@ import Cherry from './Cherry';
 
 import SyntaxHookBase from './core/SyntaxBase';
 import MenuHookBase from './toolbars/MenuBase';
-import { isBrowser } from './utils/env';
-
-// in browser
-if (isBrowser()) {
-  window.Cherry = Cherry;
-}
 
 export { SyntaxHookBase, MenuHookBase };
 

--- a/packages/cherry-markdown/src/index.core.umd.js
+++ b/packages/cherry-markdown/src/index.core.umd.js
@@ -13,9 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import CherryStream from './CherryStream';
+import Cherry, { SyntaxHookBase, MenuHookBase } from './index.core';
 
-import SyntaxHookBase from './core/SyntaxBase';
+import { isBrowser } from './utils/env';
 
-export { SyntaxHookBase };
-export default CherryStream;
+// in browser
+if (isBrowser()) {
+  window.Cherry = Cherry;
+}
+
+export { SyntaxHookBase, MenuHookBase };
+export default Cherry;

--- a/packages/cherry-markdown/src/index.stream.umd.js
+++ b/packages/cherry-markdown/src/index.stream.umd.js
@@ -13,9 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import CherryStream from './CherryStream';
+import CherryStream, { SyntaxHookBase } from './index.stream';
 
-import SyntaxHookBase from './core/SyntaxBase';
+import { isBrowser } from './utils/env';
+
+// in browser
+if (isBrowser()) {
+  window.Cherry = CherryStream;
+}
 
 export { SyntaxHookBase };
 export default CherryStream;

--- a/packages/cherry-markdown/src/index.umd.js
+++ b/packages/cherry-markdown/src/index.umd.js
@@ -13,9 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import CherryStream from './CherryStream';
+import Cherry from './index';
 
-import SyntaxHookBase from './core/SyntaxBase';
+import { isBrowser } from './utils/env';
+export * from './index';
 
-export { SyntaxHookBase };
-export default CherryStream;
+// in browser
+if (isBrowser()) {
+  window.Cherry = Cherry;
+}
+
+export default Cherry;

--- a/packages/cherry-markdown/test/build/entry-globals.spec.js
+++ b/packages/cherry-markdown/test/build/entry-globals.spec.js
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+const readProjectFile = (filePath) => readFileSync(resolve(projectRoot, filePath), 'utf-8');
+
+describe('browser global entry split', () => {
+  it('keeps ESM entries free of window.Cherry side effects', () => {
+    const esmEntries = ['src/index.js', 'src/index.core.js', 'src/index.stream.js'];
+
+    esmEntries.forEach((entry) => {
+      expect(readProjectFile(entry), entry).not.toMatch(/window\.Cherry\s*=/);
+    });
+  });
+
+  it('keeps window.Cherry assignment in UMD-only entries', () => {
+    const umdEntries = ['src/index.umd.js', 'src/index.core.umd.js', 'src/index.stream.umd.js'];
+
+    umdEntries.forEach((entry) => {
+      expect(readProjectFile(entry), entry).toMatch(/window\.Cherry\s*=/);
+    });
+  });
+});
+
+describe('browser global rollup outputs', () => {
+  it('builds full UMD and ESM bundles from separate entries without changing output paths', () => {
+    const config = readProjectFile('build/build.js');
+
+    expect(config).toMatch(/input:\s*'src\/index\.umd\.js'/);
+    expect(config).toMatch(/file:\s*'dist\/cherry-markdown\.js'/);
+    expect(config).toMatch(/format:\s*'umd'/);
+    expect(config).toMatch(/name:\s*'Cherry'/);
+    expect(config).toMatch(/input:\s*'src\/index\.js'/);
+    expect(config).toMatch(/file:\s*'dist\/cherry-markdown\.esm\.js'/);
+    expect(config).toMatch(/format:\s*'esm'/);
+    expect(config).toMatch(/export default \[umdOptions, esmOptions\]/);
+  });
+
+  it('builds core CDN bundle from the UMD-only entry without changing output path', () => {
+    const config = readProjectFile('build/rollup.core.config.js');
+
+    expect(config).toMatch(/input:\s*'src\/index\.core\.umd\.js'/);
+    expect(config).toMatch(/file:\s*'dist\/cherry-markdown\.core\.js'/);
+    expect(config).toMatch(/format:\s*'umd'/);
+    expect(config).toMatch(/name:\s*'Cherry'/);
+  });
+
+  it('builds stream UMD and ESM bundles from separate entries without changing output paths', () => {
+    const config = readProjectFile('build/rollup.stream.config.js');
+
+    expect(config).toMatch(/input:\s*'src\/index\.stream\.umd\.js'/);
+    expect(config).toMatch(/file:\s*'dist\/cherry-markdown\.stream\.js'/);
+    expect(config).toMatch(/format:\s*'umd'/);
+    expect(config).toMatch(/name:\s*'Cherry'/);
+    expect(config).toMatch(/input:\s*'src\/index\.stream\.js'/);
+    expect(config).toMatch(/file:\s*'dist\/cherry-markdown\.stream\.esm\.js'/);
+    expect(config).toMatch(/format:\s*'esm'/);
+    expect(config).toMatch(/export default \[umdOptions, esmOptions\]/);
+  });
+});


### PR DESCRIPTION

入口 | 用途 | 状态
-- | -- | --
src/index.js | full ESM | 纯 ESM，不挂全局
src/index.core.js | core ESM / shared | 纯 ESM，不挂全局
src/index.stream.js | stream ESM | 纯 ESM，不挂全局
src/index.umd.js | full CDN/UMD | 挂 window.Cherry
src/index.core.umd.js | core CDN/UMD | 挂 window.Cherry
src/index.stream.umd.js | stream CDN/UMD | 挂 window.Cherry

</body></html>