### PR TITLE
fix(cherry-markdown): render inline links whose text contains ][ bracket sequences

### DIFF
--- a/.changeset/fix-link-nested-brackets.md
+++ b/.changeset/fix-link-nested-brackets.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+Fix inline links whose display text contains `][` bracket sequences (e.g. `[[a][b]c](url)`) being left unrendered. The reference-link alternative in the link rule short-circuited such text as an undefined reference before the real `](url)` was reached; it is now removed so the inline URL is matched correctly. Defined references are still handled upstream by `CommentReference`, and undefined references still render as literal text.

--- a/packages/cherry-markdown/src/core/hooks/Link.js
+++ b/packages/cherry-markdown/src/core/hooks/Link.js
@@ -15,7 +15,7 @@
  */
 import SyntaxBase from '@/core/SyntaxBase';
 import { escapeHTMLSpecialChar as e, isValidScheme, encodeURIOnce } from '@/utils/sanitize';
-import { compileRegExp, isLookbehindSupported, NOT_ALL_WHITE_SPACES_INLINE } from '@/utils/regexp';
+import { compileRegExp, isLookbehindSupported } from '@/utils/regexp';
 import { replaceLookbehind } from '@/utils/lookbehind-replace';
 import UrlCache from '@/UrlCache';
 
@@ -78,46 +78,34 @@ export default class Link extends SyntaxBase {
    * @param {string} match 匹配的完整字符串
    * @param {string} leadingChar 正则分组一：前置字符
    * @param {string} text 正则分组二：链接文字
-   * @param {string|undefined} link 正则分组三：链接URL
+   * @param {string} link 正则分组三：链接URL
    * @param {string|undefined} title 正则分组四：链接title
-   * @param {string|undefined} ref 正则分组五：链接引用
-   * @param {string|undefined} target 正则分组六：新窗口打开
+   * @param {string|undefined} target 正则分组五：新窗口打开
    * @returns
    */
-  toHtml(match, leadingChar, text, link, title, ref, target) {
-    const refType = typeof link === 'undefined' ? 'ref' : 'url';
-    let attrs = '';
-    if (refType === 'ref') {
-      // 全局引用，理应在CommentReference中被替换，没有被替换说明没有定义引用项
-      return match;
+  toHtml(match, leadingChar, text, link, title, target) {
+    const { isValid, coreText, extraLeadingChar } = this.checkBrackets(text);
+    if (!isValid) return match;
+    let attrs = title && title.trim() !== '' ? ` title="${e(title.replace(/["']/g, ''))}"` : '';
+    if (target) {
+      attrs += ` target="${target.replace(/{target\s*=\s*(.*?)}/, '$1')}"`;
+    } else if (this.target) {
+      attrs += ` ${this.target}`;
     }
-
-    if (refType === 'url') {
-      const { isValid, coreText, extraLeadingChar } = this.checkBrackets(text);
-      if (!isValid) return match;
-      attrs = title && title.trim() !== '' ? ` title="${e(title.replace(/["']/g, ''))}"` : '';
-      if (target) {
-        attrs += ` target="${target.replace(/{target\s*=\s*(.*?)}/, '$1')}"`;
-      } else if (this.target) {
-        attrs += ` ${this.target}`;
-      }
-      let processedURL = link.trim().replace(/~1D/g, '~D'); // 还原替换的$符号
-      const processedText = coreText.replace(/~1D/g, '~D'); // 还原替换的$符号
-      // text可能是html标签，依赖htmlBlock进行处理
-      if (isValidScheme(processedURL)) {
-        processedURL = this.$engine.urlProcessor(processedURL, 'link');
-        processedURL = encodeURIOnce(processedURL);
-        const customAttrs =
-          // @ts-ignore
-          this.$engine.$cherry.options.engine.syntax.link.attrRender(processedText, processedURL) ?? '';
-        return `${leadingChar + extraLeadingChar}<a href="${UrlCache.set(processedURL)}" ${
-          typeof customAttrs === 'string' ? customAttrs : ''
-        } ${this.rel} ${attrs}>${processedText}</a>`;
-      }
-      return `${leadingChar + extraLeadingChar}<span>${text}</span>`;
+    let processedURL = link.trim().replace(/~1D/g, '~D'); // 还原替换的$符号
+    const processedText = coreText.replace(/~1D/g, '~D'); // 还原替换的$符号
+    // text可能是html标签，依赖htmlBlock进行处理
+    if (isValidScheme(processedURL)) {
+      processedURL = this.$engine.urlProcessor(processedURL, 'link');
+      processedURL = encodeURIOnce(processedURL);
+      const customAttrs =
+        // @ts-ignore
+        this.$engine.$cherry.options.engine.syntax.link.attrRender(processedText, processedURL) ?? '';
+      return `${leadingChar + extraLeadingChar}<a href="${UrlCache.set(processedURL)}" ${
+        typeof customAttrs === 'string' ? customAttrs : ''
+      } ${this.rel} ${attrs}>${processedText}</a>`;
     }
-    // should never happen
-    return match;
+    return `${leadingChar + extraLeadingChar}<span>${text}</span>`;
   }
 
   toStdMarkdown(match) {
@@ -147,24 +135,18 @@ export default class Link extends SyntaxBase {
       content: [
         '\\[([^\\n]*?)\\]', // ?<text>
         '[ \\t]*', // any spaces
-        `${
-          '(?:' +
-          '\\(' +
-          /**
-           * allow double quotes
-           * e.g.
-           * [link](") ⭕️ valid
-           * [link]("") ⭕️ valid
-           * [link](()) ⭕️ valid
-           * [link](" ") ❌ invalid
-           */
-          '((?:[^\\s()]*\\([^\\s()]*\\)[^\\s()]*)+|[^\\s)]+)' + // ?<link> url
-          '(?:[ \\t]((?:".*?")|(?:\'.*?\')))?' + // ?<title> optional
-          '\\)' +
-          '|' + // or
-          '\\[('
-        }${NOT_ALL_WHITE_SPACES_INLINE})\\](?!\\s*\\()` + // ?<ref> global ref, exclude [text][ref](url) inline link pattern
-          ')',
+        '\\(',
+        /**
+         * allow double quotes
+         * e.g.
+         * [link](") ⭕️ valid
+         * [link]("") ⭕️ valid
+         * [link](()) ⭕️ valid
+         * [link](" ") ❌ invalid
+         */
+        '((?:[^\\s()]*\\([^\\s()]*\\)[^\\s()]*)+|[^\\s)]+)', // ?<link> url
+        '(?:[ \\t]((?:".*?")|(?:\'.*?\')))?', // ?<title> optional
+        '\\)',
         '(\\{target\\s*=\\s*(_blank|parent|self|top)\\})?',
       ].join(''),
       end: '',

--- a/packages/cherry-markdown/test/core/hooks/Link.spec.ts
+++ b/packages/cherry-markdown/test/core/hooks/Link.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import Link from '../../../src/core/hooks/Link';
+
+function createLinkHook(config = {}) {
+  const hook = new Link({ config, globalConfig: {} }) as any;
+  hook.$engine = { urlProcessor: (url: string) => url };
+  hook.$engine.$cherry = {
+    options: {
+      engine: {
+        syntax: {
+          link: {
+            attrRender: (_text: string, _url: string) => '',
+          },
+        },
+      },
+    },
+  };
+  return hook;
+}
+
+describe('core/hooks/link', () => {
+  describe('makeHtml', () => {
+    it('渲染带嵌套方括号文字的行内链接 (issue #930)', () => {
+      const hook = createLinkHook();
+      const input = '[[20240803][子标题]例子段落(2)](例子.md#[20240803][子标题]例子段落(2))';
+      const html = hook.makeHtml(input);
+      // 整个文本作为一个链接被渲染，不再原样返回
+      expect(html).not.toBe(input);
+      expect(html).toContain('<a href="cherry-inner://');
+      // 展示文字保留内部的方括号段落
+      expect(html).toContain('>[20240803][子标题]例子段落(2)</a>');
+    });
+
+    it('渲染普通行内链接', () => {
+      const hook = createLinkHook();
+      const html = hook.makeHtml('[text](https://example.com)');
+      expect(html).toContain('<a href="cherry-inner://');
+      expect(html).toContain('>text</a>');
+    });
+
+    it('保留链接文字前的前缀，如 [2][t](u) -> [2]<a>t</a>', () => {
+      const hook = createLinkHook();
+      const html = hook.makeHtml('[2][text](https://example.com)');
+      expect(html).toContain('[2]<a href="cherry-inner://');
+      expect(html).toContain('>text</a>');
+    });
+
+    it('未定义的引用式链接（无行内 url）保持原样', () => {
+      const hook = createLinkHook();
+      const input = '[text][undefinedref]';
+      expect(hook.makeHtml(input)).toBe(input);
+    });
+
+    it('支持 {target=...} 属性', () => {
+      const hook = createLinkHook();
+      const html = hook.makeHtml('[text](https://example.com){target=_blank}');
+      expect(html).toContain('target="_blank"');
+      expect(html).toContain('>text</a>');
+    });
+
+    it('支持链接 title', () => {
+      const hook = createLinkHook();
+      const html = hook.makeHtml('[text](https://example.com "the title")');
+      expect(html).toContain('title="the title"');
+      expect(html).toContain('>text</a>');
+    });
+
+    it('支持 url 中的成对括号', () => {
+      const hook = createLinkHook();
+      const html = hook.makeHtml('[text](https://example.com/f(o)o)');
+      expect(html).toContain('<a href="cherry-inner://');
+      expect(html).toContain('>text</a>');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #930. An inline link whose display text contains a `][` bracket sequence, e.g.

```markdown
[[20240803][子标题]例子段落(2)](例子.md#[20240803][子标题]例子段落(2))
```

was rendered as raw text instead of a hyperlink (GitHub renders it as a single link). The collaborator `sunsonliu` said "let's fix this case", and `liu-zhijie` later confirmed it still reproduces on 0.10.3.

Root cause is in `packages/cherry-markdown/src/core/hooks/Link.js`. The link rule regex offered two alternatives after the text group: the inline `(url)` branch and a reference-link branch:

```js
'(?:' +
  '\\(' + '(...url...)' + '(...title...)?' + '\\)' +   // inline link
  '|' +
  '\\[(' + NOT_ALL_WHITE_SPACES_INLINE + ')\\](?!\\s*\\()' + // reference
')',
```

Because the text group `[^\n]*?` is non-greedy, on the input above the engine matched the shortest text (`[20240803`) and the reference branch then matched the next `[子标题]` (its `(?!\s*\()` guard passes because `]` is followed by `例`). The match was classified as a `ref`, `toHtml` returned it unchanged, and the real `](url)` further along was never reached.

That reference branch never produced rendered output anyway: defined references are already rewritten to inline `[text](url)` form by `CommentReference.beforeMakeHtml` before `Link` runs, and undefined references stay literal text either way.

The fix removes the reference-link alternative so the inline `(url)` is required. The non-greedy text group now backtracks until it reaches the real `](url)`, and `checkBrackets` correctly balances the inner brackets.

## Why this matters

Markdown link text legitimately contains bracketed segments (dates, IDs, section anchors). Today any such link is silently dropped and shown as raw source, which is a visible correctness gap versus GitHub and other CommonMark renderers.

## Changes

- `packages/cherry-markdown/src/core/hooks/Link.js`: drop the reference-link alternative and its non-capturing wrapper from the rule regex, making the `(url)` group mandatory; update `toHtml`'s signature/body (and JSDoc) to remove the now-dead `ref` handling and renumber capture groups; remove the now-unused `NOT_ALL_WHITE_SPACES_INLINE` import.
- `packages/cherry-markdown/test/core/hooks/Link.spec.ts`: new regression tests covering the issue's nested-bracket case, plain links, the `[2][t](u)` prefix case, an undefined reference staying literal, `{target=...}`, titles, and balanced parens in URLs.
- `.changeset/fix-link-nested-brackets.md`: patch changeset entry.

## Verification

- New `Link.spec.ts`: 7/7 pass.
- Full `cherry-markdown` suite: 1192 pass. No snapshot changes. (4 pre-existing failures in `test/utils/pasteHelper.spec.ts` are unrelated to this change and also fail on a clean `dev`.)
- `eslint` and `prettier --check` clean on the changed files.

Closes #930
