### PR TITLE
fix: 降低 engines.node 约束从 `>=24` 到 `>=22`

### DIFF
--- a/.changeset/silver-falcons-shop.md
+++ b/.changeset/silver-falcons-shop.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 降低 engines.node 约束从 >=24 到 >=22，兼容 Node.js 22 用户安装

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     ]
   },
   "engines": {
-    "node": ">=24",
+    "node": ">=22",
     "yarn": ">=1.22.18"
   },
   "resolutions": {

--- a/packages/cherry-markdown/package.json
+++ b/packages/cherry-markdown/package.json
@@ -54,7 +54,7 @@
   ],
   "author": "Cherry Oteam",
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",


### PR DESCRIPTION
## 问题

当前 `package.json` 和 `packages/cherry-markdown/package.json` 中 `engines.node` 设为 `>=24`，导致 Node.js 22 的用户安装时出现 engine 不匹配错误。

## 修复

将 `engines.node` 从 `>=24` 降低到 `>=22`。CI（`pr-ci.yml`）已在 `lts/*`（Node 22）和 `24.x` 上同时运行构建验证，证明项目实际兼容 Node 22。

## 修改文件

- `package.json` — engines.node: >=24 → >=22
- `packages/cherry-markdown/package.json` — engines.node: >=24 → >=22
- `.changeset/silver-falcons-shop.md` — 新 changeset