### PR TITLE
fix(searcher): 替换匹配项后不再自动滚动视口

### DIFF
--- a/.changeset/tidy-mice-learn.md
+++ b/.changeset/tidy-mice-learn.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 搜索替换匹配项后不再自动滚动视口

--- a/packages/cherry-markdown/src/toolbars/searcher/SearcherBridge.js
+++ b/packages/cherry-markdown/src/toolbars/searcher/SearcherBridge.js
@@ -120,7 +120,7 @@ export default class SearcherBridge {
     }
 
     if (this.panel.isVisible()) {
-      this.panel.scheduleSearch(true);
+      this.panel.scheduleSearch(true, false);
       return;
     }
 

--- a/packages/cherry-markdown/src/toolbars/searcher/SearcherPanel.js
+++ b/packages/cherry-markdown/src/toolbars/searcher/SearcherPanel.js
@@ -164,6 +164,8 @@ export default class SearcherPanel {
     this.searchTimer = null;
     /** @type {boolean} */
     this.pendingKeepActiveIndex = false;
+    /** @type {boolean} */
+    this.pendingScrollToMatch = true;
 
     this.handlePanelShortcutKey = this.handlePanelShortcutKey.bind(this);
 
@@ -508,12 +510,13 @@ export default class SearcherPanel {
    * 防抖调度搜索（输入或文档变更时使用）
    * @param {boolean} [keepActiveIndex=false]
    */
-  scheduleSearch(keepActiveIndex = false) {
+  scheduleSearch(keepActiveIndex = false, scrollToMatch = true) {
     this.pendingKeepActiveIndex = keepActiveIndex;
+    this.pendingScrollToMatch = scrollToMatch;
     this.cancelScheduledSearch();
     this.searchTimer = setTimeout(() => {
       this.searchTimer = null;
-      this.runSearch(this.pendingKeepActiveIndex);
+      this.runSearch(this.pendingKeepActiveIndex, this.pendingScrollToMatch);
     }, SEARCH_DEBOUNCE_MS);
   }
 
@@ -529,13 +532,13 @@ export default class SearcherPanel {
    * 立即执行待定的防抖搜索
    * @param {boolean} [keepActiveIndex=true]
    */
-  flushScheduledSearch(keepActiveIndex = true) {
+  flushScheduledSearch(keepActiveIndex = true, scrollToMatch = true) {
     if (!this.searchTimer) {
       return;
     }
 
     this.cancelScheduledSearch();
-    this.runSearch(keepActiveIndex);
+    this.runSearch(keepActiveIndex, scrollToMatch);
   }
 
   /**
@@ -544,7 +547,7 @@ export default class SearcherPanel {
    * @param {boolean} [keepActiveIndex=false]
    * @param {boolean} [applyToEditor=true]
    */
-  syncMatches(keepActiveIndex = false, applyToEditor = true) {
+  syncMatches(keepActiveIndex = false, applyToEditor = true, scrollToMatch = true) {
     if (!this.editorAdapter) {
       return;
     }
@@ -574,7 +577,9 @@ export default class SearcherPanel {
 
     if (applyToEditor) {
       this.applyHighlight(regex);
-      this.focusCurrentMatch();
+      if (scrollToMatch) {
+        this.focusCurrentMatch();
+      }
     }
 
     this.updateCounter();
@@ -585,8 +590,8 @@ export default class SearcherPanel {
    *
    * @param {boolean} [keepActiveIndex=false] 为 true 且当前序号仍有效时，不根据光标重新定位匹配项
    */
-  runSearch(keepActiveIndex = false) {
-    this.syncMatches(keepActiveIndex, true);
+  runSearch(keepActiveIndex = false, scrollToMatch = true) {
+    this.syncMatches(keepActiveIndex, true, scrollToMatch);
   }
 
   /**
@@ -736,6 +741,7 @@ export default class SearcherPanel {
     const anchor = match.from + replacement.length;
     this.editorAdapter.replaceRange(replacement, match.from, match.to);
 
+    this.cancelScheduledSearch();
     const text = this.editorAdapter.getDocString();
     const { query, caseSensitive, wholeWord, useRegex } = this.state;
     const matches = findMatches(text, query, caseSensitive, wholeWord, useRegex);
@@ -748,7 +754,6 @@ export default class SearcherPanel {
     }
 
     this.applyHighlight();
-    this.focusCurrentMatch();
     this.updateCounter();
     this.refocusPanelInput();
     return true;
@@ -787,7 +792,8 @@ export default class SearcherPanel {
       this.editorAdapter.replaceRange(replacement, from, to);
     }
 
-    this.runSearch(true);
+    this.cancelScheduledSearch();
+    this.syncMatches(true, true, false);
     this.refocusPanelInput();
   }
 


### PR DESCRIPTION
## 问题

替换匹配项后，原匹配消失，页面立刻滚动到最近的剩余匹配项。连续替换时视口频繁跳动，体验不合理。

## 原因

1. `replaceCurrent` 直接调用了 `focusCurrentMatch()`（`scrollIntoView: true`）
2. `replaceRange` 会异步触发 Cherry 的 `afterChange` 事件
3. `handleDocumentChange` 重新调度搜索 → `syncMatches` → `focusCurrentMatch` → 二次滚动

## 改动

### `SearcherPanel.js`

- **`replaceCurrent`**: 移除 `focusCurrentMatch()` 调用，添加 `cancelScheduledSearch()` 取消 `afterChange` 触发的防抖搜索
- **`replaceAll`**: 使用 `syncMatches(true, true, false)` 替代 `runSearch(true)`，同步匹配结果但不滚动
- **`syncMatches`**: 新增 `scrollToMatch` 参数（默认 true），仅在需要时调用 `focusCurrentMatch`
- **`scheduleSearch` / `runSearch` / `flushScheduledSearch`**: 新增 `scrollToMatch` 参数贯穿调用链

### `SearcherBridge.js`

- **`handleDocumentChange`**: `scheduleSearch(true, false)` — 文档变更触发的搜索同步跳过滚动（用户编辑中不抢视口）

## 行为变化

| 操作 | 是否滚动 |
|------|---------|
| 搜索框输入 / 按 Enter | ✅ 滚动到最近匹配 |
| 点上下导航按钮 | ✅ 滚动到目标匹配 |
| 替换当前 (Replace) | ❌ 不滚动 |
| 替换全部 (Replace All) | ❌ 不滚动 |
| 编辑器内手动编辑内容时 | ❌ 不滚动 |