### PR TITLE
fix(miniprogram): complete demo feature coverage

### DIFF
--- a/examples/miniProgram/miniprogram/pages/index/index.wxss
+++ b/examples/miniProgram/miniprogram/pages/index/index.wxss
@@ -13,13 +13,18 @@
 }
 
 .action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex: 1;
+  box-sizing: border-box;
   height: 72rpx;
+  padding: 0;
   border-radius: 8rpx;
   background: #1677ff;
   color: #ffffff;
   font-size: 28rpx;
-  line-height: 72rpx;
+  line-height: 1;
 }
 
 .secondary {
@@ -93,6 +98,16 @@
 
 .md-strike {
   text-decoration: line-through;
+}
+
+.md-sub {
+  vertical-align: sub;
+  font-size: 24rpx;
+}
+
+.md-sup {
+  vertical-align: super;
+  font-size: 24rpx;
 }
 
 .md-link {

--- a/examples/miniProgram/package.json
+++ b/examples/miniProgram/package.json
@@ -2,6 +2,7 @@
   "name": "@cherry-markdown/mini-program-demo",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "node build.mjs"
   },

--- a/examples/miniProgram/src/pages/index/index.js
+++ b/examples/miniProgram/src/pages/index/index.js
@@ -1,46 +1,63 @@
 import CherryStream from '@cherry-markdown/miniprogram';
 import { createMockMarkdownChunks } from '../../utils/mock-stream.js';
 
-const DEMO_MARKDOWN = `# Cherry Markdown MiniProgram
+const MARKDOWN_LINE_BREAK = '  ';
 
-这是一个 **微信小程序原生渲染** 示例，支持 *基础语法*、\`inline code\` 和 [链接点击](/pages/index/index)。
+const DEMO_MARKDOWN = `# 一级标题（#）
 
-> 这里是 blockquote，可以继续渲染子块。
+这是普通段落。每一项支持的 Markdown 语法都在下方单独展示。
 
-- 无序列表
-- 图片预览
-- 代码复制
+## 二级标题（##）
 
-![Cherry logo](/assets/logo-square.png)
+### 三级标题（###）
+
+> 引用块（>）可以包含一段文本。
+
+无序列表（-）：
+
+- 第一项
+- 第二项
+
+有序列表（1.）：
+
+1. 第一项
+2. 第二项
+
+任务列表（- [x] / - [ ]）：
+
+- [x] 已完成任务
+- [ ] 待处理任务
+
+表格：
+
+| 能力 | 语法 | 交互 |
+| --- | --- | --- |
+| 链接 | [原生 text](/pages/index/index) | 点击处理 |
+| 图片 | ![logo](/assets/logo-square.png) | 点击预览 |
+| 代码块 | 原生 view/text | 点击复制 |
+
+链接：[站内链接](/pages/index/index)
+
+自动链接：https://example.com
+
+图片：![Cherry logo](/assets/logo-square.png)
+
+代码块：
 
 \`\`\`js
 const message = 'hello mini program';
 console.log(message);
 \`\`\`
 
-## 更多基础语法
+行内公式：$E=mc^2$
 
-1. 有序列表
-2. ~~删除线~~ 和 **加粗** 可以组合测试
-3. 任务列表和表格会转换为原生 view 渲染
-
-- [x] 已完成任务
-- [ ] 待处理任务
-
-| 能力 | 渲染方式 | 交互 |
-| --- | --- | --- |
-| 链接 | [原生 text](/pages/index/index) | 点击处理 |
-| 图片 | ![logo](/assets/logo-square.png) | 点击预览 |
-| 代码块 | 原生 view/text | 点击复制 |
-| 表格 | 原生 view | 单元格内链接/图片保留交互 |
-
-## 公式与图表源码 fallback
-
-行内公式：$E=mc^2$ 会转换为 math_inline run。
+公式块：
 
 $$
 a^2 + b^2 = c^2
 $$
+
+Mermaid 源码：
 
 \`\`\`mermaid
 graph TD;
@@ -48,9 +65,32 @@ graph TD;
   B --> C[MiniProgram AST];
   C --> D[Native View];
 \`\`\`
+
+加粗：**bold**
+
+斜体：*italic*
+
+行内代码：\`inline code\`
+
+下划线：/underline/
+
+删除线：~~strikethrough~~
+
+下标：^^subscript^^
+
+上标：^superscript^
+
+显式换行：第一行后保留两个空格${MARKDOWN_LINE_BREAK}
+第二行
+
+Emoji：:smile:
+
+脚注引用：这是脚注[^demo-footnote]
+
+[^demo-footnote]: 脚注正文会以普通段落输出。
 `;
 
-const DEMO_STREAM_INTERVAL = 60;
+const DEMO_STREAM_INTERVAL = 160;
 const MARKDOWN_CHUNKS = createMockMarkdownChunks(DEMO_MARKDOWN);
 
 Page({
@@ -62,7 +102,13 @@ Page({
   },
 
   onLoad() {
-    this.cherry = new CherryStream();
+    this.cherry = new CherryStream({
+      engine: {
+        global: {
+          flowSessionCursor: 'default',
+        },
+      },
+    });
     this.resetStreamPipeline();
     this.autoStartStream();
   },
@@ -75,7 +121,10 @@ Page({
   renderMarkdown(markdown, streaming, callback) {
     this.setData({
       markdown,
-      blocks: this.cherry.setMarkdown(markdown, { deferImages: !streaming }),
+      blocks: this.cherry.setMarkdown(markdown, {
+        deferImages: !streaming,
+        forceNoCursor: !streaming,
+      }),
       streaming,
       streamButtonText: streaming ? '流式渲染中' : '重新流式渲染',
     }, callback);

--- a/examples/miniProgram/src/utils/mock-stream.js
+++ b/examples/miniProgram/src/utils/mock-stream.js
@@ -1,3 +1,11 @@
-export function createMockMarkdownChunks(markdown = '') {
-  return Array.from(String(markdown || ''));
+export function createMockMarkdownChunks(markdown = '', chunkSize = 1) {
+  const characters = Array.from(String(markdown || ''));
+  const size = Math.max(1, Number(chunkSize) || 1);
+  const chunks = [];
+
+  for (let index = 0; index < characters.length; index += size) {
+    chunks.push(characters.slice(index, index + size).join(''));
+  }
+
+  return chunks;
 }

--- a/packages/miniProgram/README.CN.md
+++ b/packages/miniProgram/README.CN.md
@@ -54,7 +54,7 @@ function onStreamComplete() {
 
 将完整累积的 Markdown 传给 `setMarkdown()`，与 Web `CherryStream.setMarkdown()` 一致。它会重新渲染当前完整内容，以保证未闭合语法也能得到正确的当前视图；包不处理 SSE 请求、字节解码、分帧或不同服务端的 JSON 协议。
 
-为了正确处理未闭合的 Markdown 语法，`setMarkdown()` 会重新渲染已累积的 Markdown。流式过程中传入 `deferImages: true` 会渲染图片占位；流完成后用 `deferImages: false` 再渲染一次真实图片。模型高频输出时，应由页面层合并 `setData` 更新（例如每 50-100 ms 一次），不要每个 chunk 都刷新。
+为了正确处理未闭合的 Markdown 语法，`setMarkdown()` 会重新渲染已累积的 Markdown。流式过程中传入 `deferImages: true` 会渲染图片占位；流完成后用 `deferImages: false` 再渲染一次真实图片。需要流光标时，配置 `engine.global.flowSessionCursor: 'default'`，并在流式过程中传入 `forceNoCursor: false`。模型高频输出时，应由页面层合并 `setData` 更新（例如每 50-100 ms 一次），不要每个 chunk 都刷新。
 
 ## 模块格式
 
@@ -81,13 +81,13 @@ function onStreamComplete() {
 | 加粗        | `**文字**`                      | `class="md-strong"`                 | ✅   |
 | 斜体        | `*文字*`                        | `class="md-em"`                     | ✅   |
 | 行内代码    | `` `代码` ``                    | `class="md-inline-code"`            | ✅   |
-| 下划线      | `++文字++`                      | `class="md-underline"`              | ✅   |
+| 下划线      | `/文字/`                        | `class="md-underline"`              | ✅   |
 | 删除线      | `~~文字~~`                      | `class="md-strike"`                 | ✅   |
-| 上标 / 下标 | `~上标~` / `^下标^`             | 行内 text 带 class                  | ✅   |
+| 下标 / 上标 | `^^文字^^` / `^文字^`           | 行内 text 带 class                  | ✅   |
 | 换行        | 行尾两空格                      | `\n` 文本                           | ✅   |
 | 自动链接    | `https://...`                   | 同链接处理                          | ✅   |
-| Emoji       | `:smile:`                       | Image 组件                          | ✅   |
-| 流光标      | （流模式专用）                  | `\|` 光标符                         | ✅   |
+| Emoji       | `:smile:`                       | Unicode 文本 run                    | ✅   |
+| 流光标      | （流模式专用）                  | `\|` 光标符，需显式配置             | ✅   |
 | 脚注引用    | `[^key]`                        | Sup/link 数据，模板负责跳转         | ✅   |
 | Panel       | `:::tip/warning/danger/success` | 普通段落，样式丢失                  | ❌   |
 | 脚注正文    | （自动生成）                    | 普通段落，样式丢失                  | ❌   |

--- a/packages/miniProgram/README.md
+++ b/packages/miniProgram/README.md
@@ -54,7 +54,7 @@ function onStreamComplete() {
 
 Pass the complete accumulated Markdown to `setMarkdown()`, matching Web `CherryStream.setMarkdown()`. It re-renders the current complete content, which preserves valid rendering for incomplete syntax. The package does not implement SSE requests, decoding, framing, or provider payload extraction.
 
-`setMarkdown()` re-renders the accumulated Markdown for correctness with incomplete syntax. While a stream is active, pass `deferImages: true` to render image placeholders; call it once with `deferImages: false` when the stream completes. For high-frequency model output, batch page-level `setData` calls (for example, every 50-100 ms) instead of updating for every chunk.
+`setMarkdown()` re-renders the accumulated Markdown for correctness with incomplete syntax. While a stream is active, pass `deferImages: true` to render image placeholders; call it once with `deferImages: false` when the stream completes. To render a flow cursor, configure `engine.global.flowSessionCursor: 'default'` and pass `forceNoCursor: false` while streaming. For high-frequency model output, batch page-level `setData` calls (for example, every 50-100 ms) instead of updating for every chunk.
 
 ## Module Formats
 
@@ -81,13 +81,13 @@ Pass the complete accumulated Markdown to `setMarkdown()`, matching Web `CherryS
 | Bold          | `**text**`                      | `class="md-strong"`                                            | ✅     |
 | Italic        | `*text*`                        | `class="md-em"`                                                | ✅     |
 | Inline Code   | `` `code` ``                    | `class="md-inline-code"`                                       | ✅     |
-| Underline     | `++text++`                      | `class="md-underline"`                                         | ✅     |
+| Underline     | `/text/`                        | `class="md-underline"`                                         | ✅     |
 | Strikethrough | `~~text~~`                      | `class="md-strike"`                                            | ✅     |
-| Sub / Sup     | `~text~` / `^text^`             | Inline text with class                                         | ✅     |
+| Sub / Sup     | `^^text^^` / `^text^`           | Inline text with class                                         | ✅     |
 | Line Break    | two trailing spaces             | `\n` in text run                                               | ✅     |
 | AutoLink      | `https://...`                   | Same as link                                                   | ✅     |
-| Emoji         | `:smile:`                       | Image component                                                | ✅     |
-| Cursor        | stream only                     | `\|` cursor symbol                                             | ✅     |
+| Emoji         | `:smile:`                       | Unicode text run                                               | ✅     |
+| Cursor        | stream only                     | `\|` cursor symbol; opt-in configuration                       | ✅     |
 | Footnote ref  | `[^key]`                        | Sup/link data; template owns navigation                        | ✅     |
 | Panel         | `:::tip/warning/danger/success` | Plain paragraph, styling lost                                  | ❌     |
 | Footnote body | generated content               | Plain paragraphs, styling lost                                 | ❌     |

--- a/packages/miniProgram/src/shared/transform.js
+++ b/packages/miniProgram/src/shared/transform.js
@@ -154,6 +154,15 @@ function isCursorAttrs(attrs = {}) {
 }
 
 /**
+ * Cherry renders its slash underline syntax as a styled span.
+ * @param {Record<string, string>} attrs
+ * @returns {boolean}
+ */
+function isUnderlineAttrs(attrs = {}) {
+  return /(?:^|;)\s*text-decoration\s*:\s*underline\s*(?:;|$)/i.test(attrs.style || '');
+}
+
+/**
  * @param {Record<string, string>} attrs
  * @returns {boolean}
  */
@@ -623,6 +632,9 @@ function nodeToInline(node) {
     case 'sup':
       return [{ type: 'sup', attrs, children }];
     case 'span':
+      if (isUnderlineAttrs(attrs)) {
+        return [{ type: 'underline', attrs, children }];
+      }
       return Object.keys(attrs).length > 0 ? [{ type: 'span', attrs, children }] : children;
     default:
       return children;

--- a/packages/miniProgram/test/stream.spec.ts
+++ b/packages/miniProgram/test/stream.spec.ts
@@ -94,6 +94,17 @@ describe('@cherry-markdown/miniprogram stream', () => {
     ]);
   });
 
+  it('renders Cherry underline spans as native underline runs', () => {
+    const stream = new CherryStream();
+
+    expect(stream.setMarkdown('/underlined/', { forceNoCursor: true })).toEqual([
+      {
+        type: 'paragraph',
+        inlines: [{ type: 'text', text: 'underlined', className: 'md-underline', href: '' }],
+      },
+    ]);
+  });
+
   it('resolves deferred image src values for post-setData activation', () => {
     const blocks = [{ type: 'image', src: '', pendingSrc: '/img.png', alt: 'A' }];
 


### PR DESCRIPTION
## Summary
- 展示 Demo 支持的全部 Markdown 语法，单独覆盖 #、##、### 及流式光标
- 修复下划线、上下标在 WXML view data 中的渲染
- 调整逐字符 Demo 模拟节奏并同步中英文文档

## Validation
- yarn workspace @cherry-markdown/miniprogram test
- yarn workspace @cherry-markdown/miniprogram typecheck
- yarn --cwd examples/miniProgram build
- git diff --check