### PR TITLE
fix: 修复引用式链接可绕过协议校验注入危险协议的问题

### DIFF
--- a/.changeset/tidy-pandas-attack.md
+++ b/.changeset/tidy-pandas-attack.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 修复引用式链接可绕过协议校验注入 `javascript:` 等危险协议的问题

--- a/packages/cherry-markdown/src/core/hooks/CommentReference.js
+++ b/packages/cherry-markdown/src/core/hooks/CommentReference.js
@@ -15,6 +15,7 @@
  */
 import ParagraphBase from '@/core/ParagraphBase';
 import { compileRegExp } from '@/utils/regexp';
+import { isValidScheme } from '@/utils/sanitize';
 import UrlCache from '@/UrlCache';
 /**
  * 脚注和引用语法
@@ -57,7 +58,13 @@ export default class CommentReference extends ParagraphBase {
 
   pushCommentReferenceCache(key, cache) {
     const [url, ...args] = cache.split(/[ ]+/g);
-    const innerUrl = UrlCache.set(this.unwrapUrl(url));
+    const unwrappedUrl = this.unwrapUrl(url);
+    // 引用式链接的 url 会被放入 UrlCache，从而绕过 Link 的协议校验和 DOMPurify，
+    // 所以必须在写入缓存前校验协议，拒绝 javascript: 等危险协议
+    if (!isValidScheme(unwrappedUrl)) {
+      return;
+    }
+    const innerUrl = UrlCache.set(unwrappedUrl);
     this.commentCache[`${key}`.toLowerCase()] = [innerUrl, ...args].join(' ');
   }
 

--- a/packages/cherry-markdown/src/utils/sanitize.js
+++ b/packages/cherry-markdown/src/utils/sanitize.js
@@ -451,7 +451,7 @@ export function isValidScheme(url) {
   if (!match) {
     return true;
   }
-  const SCHEME_BLACKLIST = ['javascript', 'data'];
+  const SCHEME_BLACKLIST = ['javascript', 'vbscript', 'data'];
   const scheme = match[1].replace(/[\s\x00-\x1f]/g, ''); // 协议中间可能会出现空白字符或控制字符绕过检查
   if (SCHEME_BLACKLIST.indexOf(scheme.toLowerCase()) !== -1) {
     return false;

--- a/packages/cherry-markdown/test/core/MarkdownRendering.spec.ts
+++ b/packages/cherry-markdown/test/core/MarkdownRendering.spec.ts
@@ -661,4 +661,32 @@ describe('Cherry Markdown final rendering', () => {
     expect(container.querySelector('div.blocked')).toBeNull();
     expect(container.textContent).toContain('<div class="blocked">Blocked</div>');
   });
+
+  it.each(['javascript:alert(document.cookie)', 'vbscript:msgbox(1)', 'data:text/html;base64,PHNjcmlwdD4='])(
+    'blocks the dangerous scheme "%s" in reference-style links',
+    (dangerousUrl) => {
+      const container = render(`[click me][ref]\n\n[ref]: ${dangerousUrl}`);
+      const anchor = container.querySelector('a');
+
+      // 危险协议的引用定义不会被解析成链接，原文按普通文本保留
+      expect(anchor).toBeNull();
+      expect(container.innerHTML).not.toContain(`${dangerousUrl.split(':')[0]}:`);
+      expect(container.textContent).toContain('[click me][ref]');
+    },
+  );
+
+  it('still renders reference-style links and images with safe schemes', () => {
+    const container = render(
+      '[guide][docs] and [docs]\n\n![logo][img]\n\n[docs]: <https://example.com/guide?q=1> "Guide"\n[img]: https://example.com/logo.png',
+    );
+    const anchors = [...container.querySelectorAll('a')];
+    const image = container.querySelector('img');
+
+    expect(anchors.map((anchor) => anchor.getAttribute('href'))).toEqual([
+      'https://example.com/guide?q=1',
+      'https://example.com/guide?q=1',
+    ]);
+    expect(anchors[0]?.getAttribute('title')).toBe('Guide');
+    expect(image?.getAttribute('src')).toBe('https://example.com/logo.png');
+  });
 });

--- a/packages/cherry-markdown/test/core/hooks/CommentReference.spec.ts
+++ b/packages/cherry-markdown/test/core/hooks/CommentReference.spec.ts
@@ -65,4 +65,18 @@ describe('core/hooks/CommentReference', () => {
 
     expect(hook.beforeMakeHtml('[docs]: https://example.com')).toBe('');
   });
+
+  it.each(['javascript:alert(1)', 'vbscript:msgbox(1)', 'data:text/html;base64,PHNjcmlwdD4='])(
+    'rejects reference definitions with the dangerous scheme %s',
+    (dangerousUrl) => {
+      const hook = createCommentReference();
+      const markdown = `A [link][ref].\n\n[ref]: ${dangerousUrl} "title"`;
+      const transformed = hook.beforeMakeHtml(markdown);
+
+      // 危险协议不写入缓存，引用保持未解析状态，不会被改写成 [text](url) 形式
+      expect(hook.getCommentReferenceCache('ref')).toBeNull();
+      expect(hook.afterMakeHtml(transformed)).not.toContain(dangerousUrl);
+      expect(transformed).toContain('[link][ref]');
+    },
+  );
 });

--- a/packages/cherry-markdown/test/utils/sanitize.spec.ts
+++ b/packages/cherry-markdown/test/utils/sanitize.spec.ts
@@ -47,6 +47,7 @@ describe('utils/sanitize', () => {
     expect(isValidScheme('relative/path')).toBe(true);
     expect(isValidScheme('https://example.com')).toBe(true);
     expect(isValidScheme('javascript:alert(1)')).toBe(false);
+    expect(isValidScheme('vbscript:msgbox(1)')).toBe(false);
     expect(isValidScheme('data:text/html;base64,abc')).toBe(false);
     expect(isValidScheme('&#x6a;avascript:alert(1)')).toBe(false);
     expect(isValidScheme('java\t script:alert(1)')).toBe(false);


### PR DESCRIPTION
## 问题

引用式链接（reference-style link）的 URL 可以绕过全部两道安全校验，注入 `javascript:` 等危险协议，造成 XSS。

**复现（默认配置即可）：**

```markdown
[点击我][xss]

[xss]: javascript:alert(document.cookie)
```

修复前最终渲染结果（已经把 `engine.makeHtml` 的完整管线包括 DOMPurify 都跑完）：

```html
<a href="javascript:alert(document.cookie)">点击我</a>
```

而普通行内写法 `[点击我](javascript:alert(1))` 是会被正确拦截的，唯独引用式写法漏了。

## 根因

1. `CommentReference.pushCommentReferenceCache` 把引用定义里的 URL **不做任何协议校验**就写入 `UrlCache`，并把 `[text][ref]` 改写成 `[text](cherry-inner://<hash>)`；
2. `Link.toHtml` 里的 `isValidScheme` 看到的只是 `cherry-inner://` 占位 URL，必然通过；
3. DOMPurify 在 `UrlCache.restoreAll` 还原真实 URL **之前**执行（`Engine.js` 中 `afterMakeHtml` 先于 restore），同样只能看到占位 URL，`cherry-inner://` 在 `ALLOW_UNKNOWN_PROTOCOLS` 下被放行；
4. 渲染出口处真实 URL 被还原，危险协议直接进入最终 HTML。

## 修复

- `CommentReference.pushCommentReferenceCache`：写入缓存前对解包后的真实 URL 调用 `isValidScheme` 校验，非法协议的引用定义直接丢弃（引用保持未解析状态，按普通文本渲染，与未定义引用的行为一致）；
- `isValidScheme` 协议黑名单补充 `vbscript`（此前仅 `javascript`、`data`，`vbscript:msgbox(1)` 可直通）；
- 新增回归测试：
  - `test/core/MarkdownRendering.spec.ts`：引擎级端到端用例（`javascript:`/`vbscript:`/`data:` 引用式链接被拦截、安全协议的引用式链接/图片正常渲染）；
  - `test/core/hooks/CommentReference.spec.ts`：hook 级用例（危险协议定义不写入缓存、不被展开）；
  - `test/utils/sanitize.spec.ts`：`vbscript` 黑名单用例。

## 验证

- 相关测试文件 96 个用例全部通过；
- 完整测试套件与基线一致（本地 Node 26 环境下有 8 个文件因 `localStorage` 实验特性缺失而失败，在未修改的基线代码上同样失败，与本次改动无关）；
- `typecheck`、`eslint`、`prettier` 均通过。