### PR TITLE
fix: 修复 setCursor 传入越界行号/列号时抛异常的问题

### DIFF
--- a/.changeset/curvy-lions-clamp.md
+++ b/.changeset/curvy-lions-clamp.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 修复 `setCursor` 传入越界行号/列号时抛异常的问题

--- a/packages/cherry-markdown/src/Editor.js
+++ b/packages/cherry-markdown/src/Editor.js
@@ -2520,8 +2520,10 @@ export default class Editor {
   setCursor(line, ch) {
     if (!this.editor) return;
     const { doc } = this.editor.state;
-    const targetLine = doc.line(line + 1);
-    const pos = targetLine.from + ch;
+    // 与 setSelection 保持一致，对行号和列号做边界钳制，避免越界时 CodeMirror 抛异常
+    const lineNum = Math.max(1, Math.min(line + 1, doc.lines));
+    const targetLine = doc.line(lineNum);
+    const pos = targetLine.from + Math.max(0, Math.min(ch, targetLine.length));
     this.editor.dispatch({
       selection: { anchor: pos, head: pos },
     });

--- a/packages/cherry-markdown/test/codemirror/SetCursor.spec.ts
+++ b/packages/cherry-markdown/test/codemirror/SetCursor.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Editor.setCursor boundary clamping regression tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { EditorView } from '@codemirror/view';
+import Editor from '../../src/Editor';
+import { createCm6View, getSelection } from '../helpers/cM6View';
+
+/**
+ * Wrap a raw CM6 EditorView into the minimal adapter shape that
+ * `Editor.setCursor` expects (state / dispatch).
+ */
+function createEditorWithView(doc: string) {
+  const view = createCm6View(doc, 0);
+  const adapter = {
+    view,
+    get state() {
+      return view.state;
+    },
+    dispatch: (...specs: Parameters<EditorView['dispatch']>) => view.dispatch(...specs),
+  };
+  const editor = Object.create(Editor.prototype);
+  editor.editor = adapter;
+  return { editor, view };
+}
+
+describe('Editor.setCursor', () => {
+  it('sets the cursor at the given line and column', () => {
+    const { editor, view } = createEditorWithView('first line\nsecond\nthird');
+
+    editor.setCursor(1, 3);
+
+    // 第二行 "second" 起始偏移为 11，列 3 对应位置 14
+    expect(getSelection(view)).toEqual({ anchor: 14, head: 14 });
+    expect(editor.getCursor()).toEqual({ line: 1, ch: 3 });
+
+    view.destroy();
+  });
+
+  it('clamps an out-of-range line to the last line instead of throwing', () => {
+    const { editor, view } = createEditorWithView('first line\nsecond\nthird');
+
+    expect(() => editor.setCursor(9999, 0)).not.toThrow();
+
+    // 钳制到最后一行 "third"（起始偏移 18）
+    expect(getSelection(view)).toEqual({ anchor: 18, head: 18 });
+    expect(editor.getCursor()).toEqual({ line: 2, ch: 0 });
+
+    view.destroy();
+  });
+
+  it('clamps a negative line to the first line instead of throwing', () => {
+    const { editor, view } = createEditorWithView('first line\nsecond\nthird');
+
+    expect(() => editor.setCursor(-5, 2)).not.toThrow();
+
+    // 钳制到第一行，列 2
+    expect(getSelection(view)).toEqual({ anchor: 2, head: 2 });
+    expect(editor.getCursor()).toEqual({ line: 0, ch: 2 });
+
+    view.destroy();
+  });
+
+  it('clamps an out-of-range column to the end of the target line', () => {
+    const { editor, view } = createEditorWithView('first line\nsecond\nthird');
+
+    expect(() => editor.setCursor(1, 999)).not.toThrow();
+
+    // 钳制到第二行行尾（偏移 17）
+    expect(getSelection(view)).toEqual({ anchor: 17, head: 17 });
+    expect(editor.getCursor()).toEqual({ line: 1, ch: 6 });
+
+    view.destroy();
+  });
+});


### PR DESCRIPTION
## 问题

公开 API `Editor.setCursor(line, ch)` 没有任何边界检查，直接调用 CodeMirror 6 的 `doc.line(line + 1)`。当调用方传入超出文档范围的行号或列号时（例如目录跳转、外部定位光标等功能根据用户操作计算位置），CM6 会抛出 `RangeError` / `Position out of range` 未捕获异常，整个调用栈中断。

**复现：**

```js
// 文档只有几行内容时
cherry.editor.setCursor(9999, 0); // RangeError: Invalid line number 10000
cherry.editor.setCursor(-5, 0);   // RangeError: Invalid line number -4
```

同文件的 `setSelection()`（Editor.js:2566）对行号和列号都做了 `Math.max/Math.min` 钳制，说明 `setCursor` 是漏写了边界处理，而非有意为之。

## 修复

参照 `setSelection` 的既有做法，对行号和列号做边界钳制：越界行号钳制到首行/末行，越界列号钳制到目标行行尾，与 `setSelection` 行为保持一致。

## 测试

新增 `test/codemirror/SetCursor.spec.ts`，基于真实 CM6 `EditorView`（复用现有 `createCm6View` helper）覆盖：

- 正常设置光标位置（含 `getCursor` 回读校验）
- 越界行号钳制到末行（修复前抛 `RangeError`）
- 负行号钳制到首行（修复前抛 `RangeError`）
- 越界列号钳制到行尾

已验证新增用例在未修复的代码上按预期失败（抛异常）、修复后全部通过；`typecheck`、`eslint`、`prettier` 均通过。