### PR TITLE
fix: 修复用户文本包含 bigData 占位符形态内容时被替换成 "undefined" 的问题

### DIFF
--- a/.changeset/spotty-pandas-restore.md
+++ b/.changeset/spotty-pandas-restore.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 修复用户文本包含 bigData 占位符形态内容时被替换成 "undefined" 的问题

--- a/packages/cherry-markdown/src/Engine.js
+++ b/packages/cherry-markdown/src/Engine.js
@@ -344,7 +344,8 @@ export default class Engine {
    */
   $deCacheBigData(md) {
     return md.replace(/bigDataBegin[^\n]+?bigDataEnd/g, (whole) => {
-      return this.cachedBigData[whole];
+      // 未命中缓存时（如用户原文中恰好包含该形态的文本）保留原文，避免被替换成 "undefined"
+      return this.cachedBigData[whole] ?? whole;
     });
   }
 

--- a/packages/cherry-markdown/test/core/Engine.spec.ts
+++ b/packages/cherry-markdown/test/core/Engine.spec.ts
@@ -162,6 +162,14 @@ describe('core/Engine', () => {
     expect(engine.$cacheBigData(fenced)).toBe(fenced);
   });
 
+  it('keeps original text when a big-data placeholder has no cache entry', () => {
+    const engine = createEngine();
+    // 用户原文中恰好包含占位符形态的文本时，不应被替换成 "undefined"
+    const literal = '前文 bigDataBegin123abcbigDataEnd 后文';
+
+    expect(engine.$deCacheBigData(literal)).toBe(literal);
+  });
+
   it('restores and eventually clears configured flow cursor DOM', () => {
     vi.useFakeTimers();
     const engine = createEngine();


### PR DESCRIPTION
## 问题

`Engine.$deCacheBigData`（Engine.js:345）用正则 `/bigDataBegin[^\n]+?bigDataEnd/g` 匹配占位符并直接返回 `this.cachedBigData[whole]`。当用户**在正文中恰好写下该形态的文本**时（不需要任何特殊语法，普通段落即可），会命中正则但缓存中没有对应 key，`replace` 回调返回 `undefined`，被转成字符串 `"undefined"` 写入最终 HTML——**用户原文被静默篡改，属于数据损坏**。

**复现：**

```markdown
前文 bigDataBegin123abcbigDataEnd 后文
```

修复前渲染结果中这段文本变成 `前文 undefined 后文`。

同文件 `$cacheBigData` 里还原代码块时已经用了 `codeBlocks[index] ?? ''` 做兜底（Engine.js:338），唯独 `$deCacheBigData` 漏了。

## 修复

未命中缓存时保留原文：

```diff
- return this.cachedBigData[whole];
+ // 未命中缓存时（如用户原文中恰好包含该形态的文本）保留原文，避免被替换成 "undefined"
+ return this.cachedBigData[whole] ?? whole;
```

## 测试

在 `test/core/Engine.spec.ts` 新增用例：未命中缓存的占位符形态文本原样保留（修复前该用例失败，输出 `前文 undefined 后文`）；既有的 `$cacheBigData`/$deCacheBigData` 往返用例继续通过。`typecheck`、`eslint`、`prettier` 均通过。