### PR TITLE
build: migrate Vite minification to Oxc

### DIFF
--- a/.changeset/use-oxc-minifier.md
+++ b/.changeset/use-oxc-minifier.md
@@ -1,0 +1,7 @@
+---
+'cherry-markdown': patch
+'@cherry-markdown/miniprogram': patch
+'cherry-markdown-vscode-plugin': patch
+---
+
+切换发布构建产物的 JavaScript 压缩器为 Oxc，更新相关包的构建产物。

--- a/packages/cherry-markdown/build/addons.build.js
+++ b/packages/cherry-markdown/build/addons.build.js
@@ -41,7 +41,7 @@ for (const entry of addonEntries) {
         outDir: outputDir,
         emptyOutDir: false,
         target: 'es2015',
-        minify: 'esbuild',
+        minify: 'oxc',
         lib: {
           entry: input,
           formats: [format],

--- a/packages/miniProgram/build/vite.build.js
+++ b/packages/miniProgram/build/vite.build.js
@@ -23,7 +23,7 @@ await build({
   build: {
     emptyOutDir: false,
     target: 'es2015',
-    minify: 'esbuild',
+    minify: 'oxc',
     lib: {
       entry: resolve(root, 'src/index.js'),
       formats: ['es'],

--- a/packages/vscodePlugin/vite.config.mts
+++ b/packages/vscodePlugin/vite.config.mts
@@ -20,7 +20,7 @@ const extensionConfig: UserConfig = {
     outDir: path.resolve(packageRoot, 'dist'),
     emptyOutDir: true,
     sourcemap: false,
-    minify: 'esbuild',
+    minify: 'oxc',
     lib: {
       entry: path.resolve(packageRoot, 'src/extension.ts'),
       formats: ['cjs'],
@@ -54,7 +54,7 @@ const webviewConfig: UserConfig = {
     outDir: webviewDist,
     emptyOutDir: true,
     sourcemap: false,
-    minify: 'esbuild',
+    minify: 'oxc',
     assetsInlineLimit: 0,
     rollupOptions: {
       input: path.resolve(packageRoot, 'web-resources/scripts/index.ts'),


### PR DESCRIPTION
## Summary

- replace `esbuild` minification with the Vite 8 `oxc` minifier in the addon, MiniProgram, and VS Code plugin builds
- keep this build-tool migration separate from dependency governance

## Validation

- core package build passed
- MiniProgram build passed
- `@cherry-markdown/client` production build passed
- Vite preview server started successfully at `http://127.0.0.1:4173/`

## Changeset

No changeset is included because this only changes development build tooling and does not change a published package API or runtime dependency contract.