### PR TITLE
fix(client): launch Tauri desktop mode in dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ yarn dev
 
 | 目的 | 命令 |
 | --- | --- |
-| 启动桌面客户端前端 | `yarn dev:client` |
+| 启动桌面客户端（Tauri） | `yarn dev:client` |
 | 启动 React 示例 | `yarn example:react` |
 | 构建全部 workspace | `yarn build` |
 | 只构建核心包 / 小程序包 | `yarn build:core` / `yarn build:miniProgram` |

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "vp run -F cherry-markdown build && vp run -F @cherry-markdown/miniprogram build && vp run -F @cherry-markdown/mini-program-demo build && vp run -F @cherry-markdown/react_demo build && vp run -F @cherry-markdown/client build && vp run -F cherry-markdown-vscode-plugin build",
     "build:core": "vp run -F cherry-markdown build",
     "build:miniProgram": "vp run -F @cherry-markdown/miniprogram build",
-    "dev:client": "vp run -F @cherry-markdown/client dev",
+    "dev:client": "vp run -F @cherry-markdown/client tauri:dev",
     "build:client": "vp run -F @cherry-markdown/client build",
     "build:vscodePlugin": "vp run -F cherry-markdown build && vp run -F cherry-markdown-vscode-plugin build",
     "example:react": "vp run -F @cherry-markdown/react_demo dev",

--- a/packages/client/CONTRIBUTING.md
+++ b/packages/client/CONTRIBUTING.md
@@ -19,11 +19,11 @@ Install dependencies from the repository root with Yarn; do not create a separat
 yarn install
 ```
 
-The client is a workspace managed by Vite+. Its package scripts are run through the root workspace, for example `yarn dev:client` and `yarn build:client`.
+The client is a workspace managed by Vite+. `yarn dev:client` invokes `tauri dev` and opens the native desktop client; use the package-level `dev` script only when you need the standalone web server.
 
 ### Development
 
-- Start the client frontend in development mode.
+- Start the native Tauri client in development mode.
 
 ```shell
 yarn dev:client
@@ -36,7 +36,9 @@ yarn dev:client
 yarn build:client
 ```
 
-For the native Tauri bundle, run the client workspace task through Vite+ after installing Rust and the platform dependencies:
+The root command runs the package `tauri:dev` script through Vite+, which invokes the Tauri CLI. After installing Rust and the platform dependencies, it starts the native window and the Vite dev server configured in `src-tauri/tauri.conf.json`.
+
+For the native Tauri bundle, run:
 
 ```shell
 ./node_modules/.bin/vp run -F @cherry-markdown/client tauri:build

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx node ./scripts/sync-version.js && vp dev",
+    "tauri:dev": "npx node ./scripts/sync-version.js && tauri dev",
     "build": "npx node ./scripts/sync-version.js && vue-tsc --noEmit && vp build",
     "tauri:build": "tauri build",
     "preview": "vp preview",

--- a/packages/client/src-tauri/Cargo.lock
+++ b/packages/client/src-tauri/Cargo.lock
@@ -508,7 +508,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cherry-markdown-client"
-version = "0.3.1"
+version = "0.5.0"
 dependencies = [
  "lazy_static",
  "serde",

--- a/packages/client/src-tauri/Cargo.toml
+++ b/packages/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cherry-markdown-client"
-version = "0.4.1"
+version = "0.5.0"
 description = "A Cherry Markdown Client"
 authors = ["Cherry OTeam"]
 edition = "2021"

--- a/packages/client/src-tauri/tauri.conf.json
+++ b/packages/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cherry-markdown",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "identifier": "com.cherry-markdown.app",
   "build": {
     "beforeDevCommand": "vp run dev",


### PR DESCRIPTION
## Summary
- make `yarn dev:client` invoke the Tauri CLI and open the native desktop client
- keep standalone web development available through the package `dev` script
- synchronize Tauri and Cargo versions with the client package version `0.5.0`

## Validation
- `git diff --check`
- Vite+ resolved and invoked `tauri dev`; local startup was blocked by the sandbox port binding restriction on `localhost:1420`
- commit hook completed with 0 errors (existing repository lint warnings remain)