### PR TITLE
fix: 公式渲染失败时回退源码并标红非法控制字符

### DIFF
--- a/packages/cherry-markdown/src/core/hooks/InlineMath.js
+++ b/packages/cherry-markdown/src/core/hooks/InlineMath.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import ParagraphBase from '@/core/ParagraphBase';
-import { escapeFormulaPunctuations, LoadMathModule } from '@/utils/mathjax';
+import { escapeFormulaPunctuations, LoadMathModule, renderMathFallback } from '@/utils/mathjax';
 import { getHTML } from '@/utils/dom';
 import { isBrowser } from '@/utils/env';
 import { getTableRule, isLookbehindSupported, mathBlockReg } from '@/utils/regexp';
@@ -63,9 +63,14 @@ export default class InlineMath extends ParagraphBase {
         result = `${leadingChar}<span data-sign="${sign}" class="Cherry-InlineMath cherry-katex-need-render" data-type="mathBlock" data-formula-source="${encodedFormulaSource}" data-lines="${lines}" data-content="${encodeURIComponent($m1)}"></span>`;
         this.$engine.asyncRenderHandler.add(`math-inline-${sign}`);
       } else {
-        let html = this.katex.renderToString($m1, {
-          throwOnError: false,
-        });
+        let html;
+        try {
+          html = this.katex.renderToString($m1, {
+            throwOnError: false,
+          });
+        } catch (e) {
+          html = renderMathFallback($m1, false);
+        }
         if (this.isSelfClosing()) {
           if (/class="katex-error"/.test(html) && this.lastCode) {
             html = this.lastCode;
@@ -81,7 +86,12 @@ export default class InlineMath extends ParagraphBase {
         result = `${leadingChar}<span data-sign="${sign}" class="Cherry-InlineMath cherry-mathjax-need-render" data-type="mathBlock" data-formula-source="${encodedFormulaSource}" data-lines="${lines}" data-content="${encodeURIComponent($m1)}"></span>`;
         this.$engine.asyncRenderHandler.add(`math-inline-${sign}`);
       } else {
-        let svg = getHTML(this.MathJax.tex2svg($m1, { em: 12, ex: 6, display: false }), true);
+        let svg;
+        try {
+          svg = getHTML(this.MathJax.tex2svg($m1, { em: 12, ex: 6, display: false }), true);
+        } catch (e) {
+          svg = renderMathFallback($m1, false);
+        }
         if (this.isSelfClosing()) {
           if (/data-mml-node="merror"/.test(svg) && this.lastCode) {
             svg = this.lastCode;

--- a/packages/cherry-markdown/src/core/hooks/MathBlock.js
+++ b/packages/cherry-markdown/src/core/hooks/MathBlock.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import ParagraphBase from '@/core/ParagraphBase';
-import { escapeFormulaPunctuations, LoadMathModule } from '@/utils/mathjax';
+import { escapeFormulaPunctuations, LoadMathModule, renderMathFallback } from '@/utils/mathjax';
 import { getHTML } from '@/utils/dom';
 import { isBrowser } from '@/utils/env';
 import { isLookbehindSupported } from '@/utils/regexp';
@@ -70,10 +70,15 @@ export default class MathBlock extends ParagraphBase {
         result = `<div data-sign="${sign}" class="Cherry-Math cherry-katex-need-render" data-type="mathBlock" data-formula-source="${encodedFormulaSource}" data-lines="${lines}" data-content="${encodeURIComponent($content)}"></div>`;
         this.$engine.asyncRenderHandler.add(`math-block-${sign}`);
       } else {
-        let html = this.katex.renderToString($content, {
-          throwOnError: false,
-          displayMode: true,
-        });
+        let html;
+        try {
+          html = this.katex.renderToString($content, {
+            throwOnError: false,
+            displayMode: true,
+          });
+        } catch (e) {
+          html = renderMathFallback($content, true);
+        }
         if (this.isSelfClosing()) {
           if (/class="katex-error"/.test(html) && this.lastCode) {
             html = this.lastCode;
@@ -94,8 +99,10 @@ export default class MathBlock extends ParagraphBase {
         try {
           svg = getHTML(this.MathJax.tex2svg($content), true);
         } catch (e) {
-          if (this.isSelfClosing()) {
+          if (this.isSelfClosing() && this.lastCode) {
             svg = this.lastCode;
+          } else {
+            svg = renderMathFallback($content, true);
           }
         }
 

--- a/packages/cherry-markdown/src/utils/math-loader.js
+++ b/packages/cherry-markdown/src/utils/math-loader.js
@@ -15,7 +15,7 @@
  */
 import { isBrowser } from './env';
 import { getExternal } from './external';
-import { configureMathJax } from './mathjax';
+import { configureMathJax, renderMathFallback } from './mathjax';
 import { loadCSS, loadScript, getHTML } from './dom';
 
 /**
@@ -106,7 +106,7 @@ function setupMathJax(engine, syntax) {
             true,
           );
         } catch (e) {
-          return '';
+          return renderMathFallback(content, isDisplayMode);
         }
       };
       rerenderPendingMath(engine, { className: 'cherry-mathjax-need-render', render });
@@ -133,11 +133,16 @@ function setupKatex(engine, syntax) {
     if (!resolvedKatex) {
       return;
     }
-    const render = (content, isDisplayMode) =>
-      resolvedKatex.renderToString(content, {
-        throwOnError: false,
-        displayMode: isDisplayMode,
-      });
+    const render = (content, isDisplayMode) => {
+      try {
+        return resolvedKatex.renderToString(content, {
+          throwOnError: false,
+          displayMode: isDisplayMode,
+        });
+      } catch (e) {
+        return renderMathFallback(content, isDisplayMode);
+      }
+    };
     rerenderPendingMath(engine, { className: 'cherry-katex-need-render', render });
   });
 }

--- a/packages/cherry-markdown/src/utils/mathjax.js
+++ b/packages/cherry-markdown/src/utils/mathjax.js
@@ -71,6 +71,25 @@ export const configureMathJax = (usePlugins) => {
   }
 };
 
+// 控制字符（U+0000–U+001F 以及 U+007F）在 LaTeX 中是非法的，
+// MathJax / KaTeX 遇到这类字符（如退格 \x08）时可能直接抛异常，导致整篇预览渲染中断。
+const INVALID_MATH_CHAR_REG = /[\u0000-\u001f\u007f]/g;
+
+/**
+ * 公式渲染失败时的兜底：回显原始源码，并把其中的非法控制字符用红色标出。
+ * @param {string} content 原始公式源码（不含 $ / $$ 定界符）
+ * @param {boolean} isDisplayMode 是否为块级公式（决定用 $$ 还是 $ 包裹）
+ * @returns {string} HTML 字符串
+ */
+export function renderMathFallback(content, isDisplayMode) {
+  const delimiters = isDisplayMode ? '$$' : '$';
+  const body = escapeHTMLSpecialChar(content).replace(INVALID_MATH_CHAR_REG, (char) => {
+    const hex = char.charCodeAt(0).toString(16).padStart(2, '0');
+    return `<span class="cherry-math-error" style="color:red">\\x${hex}</span>`;
+  });
+  return `${delimiters}${body}${delimiters}`;
+}
+
 const noEscape = ['&', '<', '>', '"', "'"]; // 需要转换为HTML实体字符的符号
 
 // 用于预处理会在Markdown中被反转义的字符，如：\\ 会被反转义为 \

--- a/packages/cherry-markdown/src/utils/mathjax.js
+++ b/packages/cherry-markdown/src/utils/mathjax.js
@@ -52,7 +52,7 @@ export const configureMathJax = (usePlugins) => {
           ['\\[', '\\]'],
         ],
         tags: 'ams',
-        packages: { '[+]': ['noerrors', 'cancel', 'color'] },
+        packages: { '[+]': ['noerrors', 'cancel', 'color', 'boldsymbol'] },
         macros: {
           bm: ['{\\boldsymbol{#1}}', 1],
         },

--- a/packages/cherry-markdown/test/core/hooks/InlineMath.spec.ts
+++ b/packages/cherry-markdown/test/core/hooks/InlineMath.spec.ts
@@ -141,6 +141,34 @@ describe('core/hooks/InlineMath', () => {
     expect(html).not.toContain('merror');
   });
 
+  it('falls back to raw source with red-highlighted control chars when MathJax throws', () => {
+    const tex2svg = vi.fn(() => {
+      throw new Error('invalid formula');
+    });
+    const { hook } = createInlineMath('MathJax');
+    setExternals(hook, { MathJax: { tex2svg } });
+
+    const html = hook.restoreCache(hook.toHtml('~D\x08oldsymbol a~D', '', '\x08oldsymbol a'));
+
+    expect(html).toContain('cherry-math-error');
+    expect(html).toContain('\\x08');
+    expect(html).toContain('oldsymbol a');
+    expect(html).not.toContain('<mjx-container');
+  });
+
+  it('falls back to raw source when KaTeX rendering throws', () => {
+    const renderToString = vi.fn(() => {
+      throw new Error('invalid formula');
+    });
+    const { hook } = createInlineMath('katex');
+    setExternals(hook, { katex: { renderToString } });
+
+    const html = hook.restoreCache(hook.toHtml('~Dx~D', '', 'x'));
+
+    expect(html).toContain('$x$');
+    expect(html).not.toContain('class="katex"');
+  });
+
   it('renders escaped source when running with the node engine', () => {
     const { hook } = createInlineMath('MathJax');
     hook.engine = 'node';

--- a/packages/cherry-markdown/test/core/hooks/MathBlock.spec.ts
+++ b/packages/cherry-markdown/test/core/hooks/MathBlock.spec.ts
@@ -142,6 +142,19 @@ describe('core/hooks/MathBlock', () => {
     expect(html).toContain('<text>valid</text>');
   });
 
+  it('falls back to raw source when a non-self-closing MathJax block throws', () => {
+    const tex2svg = vi.fn(() => {
+      throw new Error('invalid formula');
+    });
+    const { hook } = createMathBlock('MathJax');
+    setExternals(hook, { MathJax: { tex2svg } });
+
+    const html = hook.restoreCache(hook.toHtml('~D~Dx+y~D~D', '', '', 'x+y'));
+
+    expect(html).toContain('$$x+y$$');
+    expect(html).not.toContain('<mjx-container');
+  });
+
   it('reuses the last valid MathJax block for an merror node', () => {
     const tex2svg = vi
       .fn()

--- a/packages/cherry-markdown/test/utils/math-loader.spec.ts
+++ b/packages/cherry-markdown/test/utils/math-loader.spec.ts
@@ -184,6 +184,8 @@ describe('utils/math-loader', () => {
     expect(loadScriptMock).toHaveBeenCalledWith('/mathjax-inline.js', 'mathjax-js');
     expect(engine.$cherry.previewer.getDom().querySelector('.cherry-mathjax-need-render')).toBeNull();
     expect(engine.asyncRenderHandler.md).not.toContain('cherry-mathjax-need-render');
+    expect(engine.asyncRenderHandler.md).toContain('$$x+1$$');
+    expect(engine.asyncRenderHandler.md).toContain('$y+1$');
   });
 
   it('renders MathJax immediately when a loaded version has no startup promise', async () => {

--- a/packages/cherry-markdown/test/utils/mathjax.spec.ts
+++ b/packages/cherry-markdown/test/utils/mathjax.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vite-plus/test';
-import { configureMathJax, escapeFormulaPunctuations, LoadMathModule } from '../../src/utils/mathjax';
+import { configureMathJax, escapeFormulaPunctuations, LoadMathModule, renderMathFallback } from '../../src/utils/mathjax';
 
 interface MathHost {
   $externals: {
@@ -44,7 +44,7 @@ describe('utils/mathjax', () => {
       startup: { elements: ['.Cherry-Math', '.Cherry-InlineMath'], typeset: true },
       tex: {
         tags: 'ams',
-        packages: { '[+]': ['noerrors', 'cancel', 'color'] },
+        packages: { '[+]': ['noerrors', 'cancel', 'color', 'boldsymbol'] },
         macros: { bm: ['{\\boldsymbol{#1}}', 1] },
       },
       options: { enableMenu: false, processHtmlClass: 'tex2jax_process' },
@@ -74,5 +74,19 @@ describe('utils/mathjax', () => {
     const formula = escapeFormulaPunctuations('x_1 + <tag> & "quoted"');
 
     expect(formula).toBe('x\\_1 \\+ &lt;tag&gt; &amp; &quot;quoted&quot;');
+  });
+
+  it('renders raw source and highlights illegal control characters in red', () => {
+    expect(renderMathFallback('\x08oldsymbol a', false)).toBe(
+      '$<span class="cherry-math-error" style="color:red">\\x08</span>oldsymbol a$',
+    );
+  });
+
+  it('escapes HTML-sensitive characters in the fallback source', () => {
+    expect(renderMathFallback('a < b', false)).toBe('$a &lt; b$');
+  });
+
+  it('wraps block formulas with display delimiters', () => {
+    expect(renderMathFallback('x + y', true)).toBe('$$x + y$$');
   });
 });

--- a/packages/vscodePlugin/package.json
+++ b/packages/vscodePlugin/package.json
@@ -2,7 +2,7 @@
   "name": "cherry-markdown-vscode-plugin",
   "displayName": "Cherry Markdown",
   "description": "A markdown previewer powered by [cherry-markdown](https://github.com/Tencent/cherry-markdown) for VSCode",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "publisher": "cherryMarkdownPublisher",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/vscodePlugin/package.json
+++ b/packages/vscodePlugin/package.json
@@ -2,7 +2,7 @@
   "name": "cherry-markdown-vscode-plugin",
   "displayName": "Cherry Markdown",
   "description": "A markdown previewer powered by [cherry-markdown](https://github.com/Tencent/cherry-markdown) for VSCode",
-  "version": "0.3.2",
+  "version": "0.3.9",
   "publisher": "cherryMarkdownPublisher",
   "license": "Apache-2.0",
   "keywords": [
@@ -178,7 +178,7 @@
     "vscode:prepublish": "vp build --mode extension && vp build --mode webview && vp test run test/package.test.ts",
     "typecheck": "tsc --noEmit",
     "test": "vp run test:unit && vp run test:integration",
-    "test:unit": "vp test run test/config.test.ts test/protocol.test.ts test/textEdit.test.ts test/upload.test.ts test/webview.test.ts",
+    "test:unit": "vp test run test/config.test.ts test/protocol.test.ts test/textEdit.test.ts test/upload.test.ts test/webview.test.ts test/mathjaxConfig.test.ts test/editState.test.ts",
     "test:package": "vp test run test/package.test.ts",
     "test:vsix": "vp test run test/vsix.test.ts",
     "test:integration": "vp run build && tsc && node out/test/runIntegrationTests.js",

--- a/packages/vscodePlugin/src/editState.ts
+++ b/packages/vscodePlugin/src/editState.ts
@@ -1,0 +1,10 @@
+export function isPreviewEditEnabled(
+  targetDocumentUri: string | undefined,
+  targetLanguageId: string | undefined,
+  activeDocumentUri: string | undefined,
+  activeLanguageId: string | undefined,
+): boolean {
+  if (!targetDocumentUri || targetLanguageId !== 'markdown') return false;
+  if (activeLanguageId === undefined) return true;
+  return activeLanguageId === 'markdown' && activeDocumentUri === targetDocumentUri;
+}

--- a/packages/vscodePlugin/src/extension.ts
+++ b/packages/vscodePlugin/src/extension.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { getTheme, getUsageMode, migrateImageUploadMode, migrateTheme, THEME_STATE_KEY } from './config';
+import { isPreviewEditEnabled } from './editState';
 import { uploadFileHandler } from './handler/uploadFile';
 import type { EditorState, ExtensionToWebviewMessage } from './protocol';
 import { parseWebviewMessage } from './protocol';
@@ -152,7 +153,10 @@ class CherryMarkdownPreview {
   }
 
   private async handleActiveEditorChange(editor: vscode.TextEditor | undefined): Promise<void> {
-    if (editor?.document.languageId === 'markdown') {
+    // The active text editor is temporarily undefined while focus moves to the preview Webview.
+    if (!editor) return;
+
+    if (editor.document.languageId === 'markdown') {
       this.targetEditor = editor;
       if (this.panel) {
         this.updateResourceRoots();
@@ -169,10 +173,11 @@ class CherryMarkdownPreview {
 
   private isEditEnabled(): boolean {
     const activeEditor = vscode.window.activeTextEditor;
-    return Boolean(
-      activeEditor?.document.languageId === 'markdown' &&
-      this.targetEditor &&
-      sameUri(activeEditor.document.uri, this.targetEditor.document.uri),
+    return isPreviewEditEnabled(
+      this.targetEditor?.document.uri.toString(),
+      this.targetEditor?.document.languageId,
+      activeEditor?.document.uri.toString(),
+      activeEditor?.document.languageId,
     );
   }
 

--- a/packages/vscodePlugin/src/mathjaxConfig.ts
+++ b/packages/vscodePlugin/src/mathjaxConfig.ts
@@ -1,0 +1,60 @@
+export const MATHJAX_MODULE = 'mathjax/es5/tex-svg-full.js';
+export interface VSCodeMathJaxConfig {
+  loader: {
+    load: string[];
+  };
+  tex: {
+    inlineMath: string[][];
+    displayMath: string[][];
+    tags: 'ams';
+    packages: { '[+]': string[] };
+    macros: {
+      bm: [string, 1];
+    };
+  };
+  options: {
+    skipHtmlTags: string[];
+    ignoreHtmlClass: string;
+    processHtmlClass: string;
+    enableMenu: boolean;
+  };
+}
+
+export function getVSCodeMathJaxConfig(): VSCodeMathJaxConfig {
+  return {
+    loader: {
+      load: [],
+    },
+    tex: {
+      inlineMath: [
+        ['$', '$'],
+        ['\\(', '\\)'],
+      ],
+      displayMath: [
+        ['$$', '$$'],
+        ['\\[', '\\]'],
+      ],
+      tags: 'ams',
+      packages: { '[+]': ['noerrors', 'cancel', 'color', 'boldsymbol'] },
+      macros: {
+        bm: ['{\\boldsymbol{#1}}', 1],
+      },
+    },
+    options: {
+      skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code', 'a'],
+      ignoreHtmlClass: 'tex2jax_ignore',
+      processHtmlClass: 'tex2jax_process',
+      enableMenu: false,
+    },
+  };
+}
+
+export async function waitForMathJax(mathJax: {
+  startup?: { promise?: Promise<unknown> };
+}): Promise<void> {
+  try {
+    await (mathJax.startup?.promise ?? Promise.resolve());
+  } catch {
+    // Keep the preview available even when an optional MathJax extension fails.
+  }
+}

--- a/packages/vscodePlugin/test/editState.test.ts
+++ b/packages/vscodePlugin/test/editState.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { isPreviewEditEnabled } from '../src/editState';
+
+describe('preview edit activation', () => {
+  test('keeps editing enabled while the preview webview has focus', () => {
+    expect(isPreviewEditEnabled('file:///workspace/readme.md', 'markdown', undefined, undefined)).toBe(true);
+  });
+
+  test('enables editing when the matching Markdown editor is active', () => {
+    expect(
+      isPreviewEditEnabled(
+        'file:///workspace/readme.md',
+        'markdown',
+        'file:///workspace/readme.md',
+        'markdown',
+      ),
+    ).toBe(true);
+  });
+
+  test('disables editing when another editor is active', () => {
+    expect(
+      isPreviewEditEnabled(
+        'file:///workspace/readme.md',
+        'markdown',
+        'file:///workspace/notes.txt',
+        'plaintext',
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/vscodePlugin/test/mathjaxConfig.test.ts
+++ b/packages/vscodePlugin/test/mathjaxConfig.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { getVSCodeMathJaxConfig, MATHJAX_MODULE, waitForMathJax } from '../src/mathjaxConfig';
+
+describe('VS Code MathJax configuration', () => {
+  test('uses the full MathJax bundle without triggering network component loads', () => {
+    const config = getVSCodeMathJaxConfig();
+
+    expect(config.loader.load).toEqual([]);
+    expect(MATHJAX_MODULE).toBe('mathjax/es5/tex-svg-full.js');
+    expect(config.tex.packages['[+]']).toContain('boldsymbol');
+    expect(config.tex.macros.bm).toEqual(['{\\boldsymbol{#1}}', 1]);
+  });
+
+  test('does not block preview when MathJax startup fails', async () => {
+    const startup = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('startup failed')), 0),
+    );
+
+    await expect(waitForMathJax({ startup: { promise: startup } })).resolves.toBeUndefined();
+  });
+});

--- a/packages/vscodePlugin/web-resources/scripts/index.ts
+++ b/packages/vscodePlugin/web-resources/scripts/index.ts
@@ -1,6 +1,7 @@
 import Cherry from 'cherry-markdown';
 import 'cherry-markdown/dist/cherry-markdown.min.css';
 import type { CherryTheme } from '../../src/config';
+import { getVSCodeMathJaxConfig, waitForMathJax } from '../../src/mathjaxConfig';
 import type {
   EditorState,
   ExtensionToWebviewMessage,
@@ -169,6 +170,7 @@ function createBasicConfig(state: EditorState): Record<string, unknown> {
         },
         mathBlock: {
           engine: 'MathJax', // katex或MathJax
+          plugins: false,
         },
         inlineMath: {
           engine: 'MathJax', // katex或MathJax
@@ -303,10 +305,14 @@ function needsMathJax(markdown: string): boolean {
 }
 
 async function ensureMathJax(markdown: string): Promise<void> {
-  if (!needsMathJax(markdown) || window.MathJax) return;
-  await import(/* webpackChunkName: "mathjax" */ 'mathjax/es5/tex-svg.js').catch((error) => {
-    console.error('MathJax load failed:', error);
-  });
+  if (!needsMathJax(markdown)) return;
+  if (!window.MathJax) window.MathJax = getVSCodeMathJaxConfig();
+  if (!('tex2svg' in (window.MathJax as object))) {
+    await import(/* webpackChunkName: "mathjax" */ 'mathjax/es5/tex-svg-full.js').catch((error) => {
+      console.error('MathJax load failed:', error);
+    });
+  }
+  if (window.MathJax) await waitForMathJax(window.MathJax);
   if (cherry && window.MathJax) cherry.options.externals.MathJax = window.MathJax;
 }
 

--- a/packages/vscodePlugin/web-resources/scripts/index.ts
+++ b/packages/vscodePlugin/web-resources/scripts/index.ts
@@ -30,6 +30,10 @@ interface CherryInstance {
   onChange(callback: (value: string | { markdown?: string }) => void): void;
   setTheme(theme: CherryTheme): void;
   setValue(value: string): void;
+  editor?: {
+    getCursor(): { line: number; ch: number };
+    setCursor(line: number, ch: number): void;
+  };
 }
 
 interface CherryConstructor {
@@ -70,6 +74,8 @@ let uploadRequestId = 0;
   let pendingMarkdown: string | undefined;
   let stateGeneration = 0;
 let editDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+let suppressScrollMessages = false;
+let suppressScrollMessagesTimer: ReturnType<typeof setTimeout> | undefined;
 const uploadCallbacks = new Map<number, UploadCallback | undefined>();
 
 /**
@@ -344,13 +350,27 @@ async function applyEditorState(state: EditorState): Promise<void> {
   await ensureMathJax(state.text);
   if (generation !== stateGeneration) return;
   if (!preserveUnacknowledgedEdit) {
+    const textChanged = editorState?.text !== state.text;
     editorState = state;
     editInFlight = undefined;
     pendingMarkdown = undefined;
     clearTimeout(editDebounceTimer);
-    suppressEditMessage = true;
-    cherry.setValue(state.text);
-    suppressEditMessage = false;
+    if (textChanged) {
+      const cursor = cherry.editor?.getCursor?.();
+      suppressEditMessage = true;
+      suppressScrollMessages = true;
+      if (suppressScrollMessagesTimer) clearTimeout(suppressScrollMessagesTimer);
+      try {
+        cherry.setValue(state.text);
+        if (cursor) cherry.editor?.setCursor?.(cursor.line, cursor.ch);
+      } finally {
+        suppressEditMessage = false;
+        suppressScrollMessagesTimer = setTimeout(() => {
+          suppressScrollMessages = false;
+          suppressScrollMessagesTimer = undefined;
+        }, 150);
+      }
+    }
   } else {
     editorState = { ...state, text: editorState?.text ?? state.text };
   }
@@ -455,6 +475,7 @@ function postScrollPosition(domContainer: HTMLElement): void {
 }
 
 function postScrollMessage(line: number): void {
+  if (suppressScrollMessages) return;
   vscode.postMessage({ type: 'preview-scroll', data: line });
 }
 

--- a/packages/vscodePlugin/web-resources/scripts/vendor.d.ts
+++ b/packages/vscodePlugin/web-resources/scripts/vendor.d.ts
@@ -4,4 +4,4 @@ declare module 'cherry-markdown' {
 }
 
 declare module 'cherry-markdown/dist/cherry-markdown.min.css';
-declare module 'mathjax/es5/tex-svg.js';
+declare module 'mathjax/es5/tex-svg-full.js';


### PR DESCRIPTION
单个坏公式（如内联公式里的控制字符 U+0008）会让 MathJax/KaTeX 抛异常，异常向上传播导致整篇预览中断（新文件空白、切换文件停留在旧内容）。现在渲染失败时回退到原始源码，并把非法控制字符用红色标出。