### PR TITLE
fix: 按实例重置段落缓存计数器，使多个 CherryEngine    实例渲染同一文档输出一致

### DIFF
--- a/.changeset/cherry-instance-determinism.md
+++ b/.changeset/cherry-instance-determinism.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: reset per-engine paragraph cache counter so fresh engine instances render identical HTML (data-sign no longer instance-dependent)

--- a/packages/cherry-markdown/src/Engine.js
+++ b/packages/cherry-markdown/src/Engine.js
@@ -46,6 +46,8 @@ export default class Engine {
     });
     this.initMath(markdownParams);
     this.$configInit(markdownParams);
+    // 实例级确定性：内建段落 hook 每次从 ~~C0 开始编号，跨实例占位符一致
+    ParagraphBase.resetCacheCounter();
     this.hookCenter = new HookCenter(hooksConfig, markdownParams, cherry);
     this.hooks = this.hookCenter.getHookList();
     this.asyncRenderHandler = new AsyncRenderHandler(cherry);

--- a/packages/cherry-markdown/src/core/ParagraphBase.js
+++ b/packages/cherry-markdown/src/core/ParagraphBase.js
@@ -29,6 +29,15 @@ export default class ParagraphBase extends SyntaxBase {
   static IN_PARAGRAPH_CACHE_KEY_PREFIX = '!';
   static IN_PARAGRAPH_CACHE_KEY_PREFIX_REGEX = '\\!';
 
+  /**
+   * 每个 Engine 实例构造前调用：把共享的段落缓存计数器归零，
+   * 使同一套内建 hook 在不同实例中获得一致的 `~~C{n}` 占位符编号，
+   * 保证跨实例渲染输出（data-sign 等）一致。
+   */
+  static resetCacheCounter() {
+    cacheCounter = 0;
+  }
+
   constructor({ needCache, defaultCache = {} } = { needCache: false }) {
     super({});
     this.needCache = !!needCache;

--- a/packages/cherry-markdown/test/core/EngineDeterminism.spec.ts
+++ b/packages/cherry-markdown/test/core/EngineDeterminism.spec.ts
@@ -12,32 +12,64 @@
  *
  * Minimal trigger (verified): "$$\n行内公式： $e=mc^2$"
  */
+import { describe, expect, it } from 'vite-plus/test';
 import CherryEngine from '../../src/index.engine.core';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import Engine from '../../src/Engine';
+
+type EngineOptions = ConstructorParameters<typeof CherryEngine>[0];
+
+function createEngine(options: EngineOptions = {}): Engine {
+  // @ts-expect-error CherryEngine's compatibility constructor returns an Engine instance.
+  return new CherryEngine(options);
+}
 
 const MINIMAL_TRIGGER = '$$\n行内公式： $e=mc^2$';
 
-function exampleMarkdown() {
-  return readFileSync(resolve(process.cwd(), 'test/example.md'), 'utf8');
+function richMarkdown() {
+  return [
+    '# Heading **bold**',
+    '',
+    'Plain paragraph with *italic* and `code` and [link](https://e.com).',
+    '',
+    '$$\n\\begin{aligned}\nE &= mc^2 \\\\\nF &= ma\n\\end{aligned}\n$$',
+    '',
+    '行内公式： $e=mc^2$',
+    '',
+    '| a | b |',
+    '| - | - |',
+    '| 1 | 2 |',
+    '',
+    '```js\nconst x = 1;\n```',
+    '',
+    '- li1',
+    '- li2',
+    '',
+    '> blockquote line',
+    '',
+    '<div data-x="1"><b>html</b></div>',
+    '',
+    // 追加最小触发形态（未闭合块级公式后接行内公式）
+    '$$\n行内公式： $e=mc^2$',
+  ].join('\n');
 }
 
-function plain(n) {
-  return Array.from({ length: n }, (_, i) => `P${i}: normal **bold ${i}** *em* and [link ${i}](https://e.com/${i}).`).join('\n\n');
+function plain(n: number) {
+  return Array.from({ length: n }, (_, i) => `P${i}: normal **bold ${i}** *em* and [link ${i}](https://e.com/${i}).`).join(
+    '\n\n',
+  );
 }
 
-// 一组覆盖常见语法形态的文档，用于通用确定性断言
 const corpus = [
   MINIMAL_TRIGGER,
+  richMarkdown(),
   plain(8),
-  '<div data-x="1"><b>bold</b></div>\n\nplain *em* after html',
   '| a | b |\n| - | - |\n| 1 | 2 |\n\nrow text',
   '```js\nconst x = 1;\n```\n\npara after code',
-  '# Heading **b**\n\n- li1\n- li2\n\n> quote',
+  '- li1\n- li2\n\n> quote',
 ];
 
-function render(md) {
-  return new CherryEngine().makeHtml(md);
+function render(md: string): string {
+  return createEngine().makeHtml(md);
 }
 
 describe('Engine cross-instance determinism', () => {
@@ -45,8 +77,8 @@ describe('Engine cross-instance determinism', () => {
     expect(render(MINIMAL_TRIGGER)).toBe(render(MINIMAL_TRIGGER));
   });
 
-  it('two fresh engines agree on the rich example document', () => {
-    const md = exampleMarkdown();
+  it('two fresh engines agree on the rich synthetic document', () => {
+    const md = richMarkdown();
     expect(render(md)).toBe(render(md));
   });
 
@@ -59,14 +91,12 @@ describe('Engine cross-instance determinism', () => {
   });
 
   it('creating more engines later does not change an existing engine output', () => {
-    const md = exampleMarkdown();
-    const e1 = new CherryEngine();
+    const md = richMarkdown();
+    const e1 = createEngine();
     const first = e1.makeHtml(md);
-    const e2 = new CherryEngine();
-    e2.makeHtml(md);
-    const e3 = new CherryEngine();
-    e3.makeHtml(MINIMAL_TRIGGER);
-    // 全局计数器在构造 e2/e3 时被归零，不应影响已存在的 e1
+    createEngine().makeHtml(md);
+    createEngine().makeHtml(MINIMAL_TRIGGER);
+    // 全局计数器在创建后续引擎时被归零，不应影响已存在的 e1
     expect(e1.makeHtml(md)).toBe(first);
   });
 });

--- a/packages/cherry-markdown/test/core/EngineDeterminism.spec.ts
+++ b/packages/cherry-markdown/test/core/EngineDeterminism.spec.ts
@@ -10,10 +10,11 @@
  */
 import CherryEngine from '../../src/index.engine.core';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 function richMarkdown() {
   // 文档需同时包含段落级占位与行内公式，触发“hash 内容含另一 hook 占位符”路径
-  return readFileSync(new URL('../example.md', import.meta.url), 'utf8');
+  return readFileSync(resolve(process.cwd(), 'test/example.md'), 'utf8');
 }
 
 describe('Engine cross-instance determinism', () => {

--- a/packages/cherry-markdown/test/core/EngineDeterminism.spec.ts
+++ b/packages/cherry-markdown/test/core/EngineDeterminism.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test: two fresh engine instances must render the same document
+ * to byte-identical HTML.
+ *
+ * Motivation: paragraph-level cache key prefixes (~~C{n}) come from a
+ * module-level counter shared across instances. On documents where a block's
+ * hashed content still contains another hook's placeholder token, `data-sign`
+ * ends up instance-dependent, so fresh instances produce slightly different
+ * HTML (previously only stable within one instance).
+ */
+import CherryEngine from '../../src/index.engine.core';
+import { readFileSync } from 'node:fs';
+
+function richMarkdown() {
+  // 文档需同时包含段落级占位与行内公式，触发“hash 内容含另一 hook 占位符”路径
+  return readFileSync(new URL('../example.md', import.meta.url), 'utf8');
+}
+
+describe('Engine cross-instance determinism', () => {
+  it('two fresh engines produce byte-identical HTML for the same document', () => {
+    const md = richMarkdown();
+    const htmlA = new CherryEngine().makeHtml(md);
+    const htmlB = new CherryEngine().makeHtml(md);
+    expect(htmlA).toBe(htmlB);
+  });
+
+  it('three fresh engines all agree (stability)', () => {
+    const md = richMarkdown();
+    const outs = [new CherryEngine().makeHtml(md), new CherryEngine().makeHtml(md), new CherryEngine().makeHtml(md)];
+    expect(outs[1]).toBe(outs[0]);
+    expect(outs[2]).toBe(outs[0]);
+  });
+});

--- a/packages/cherry-markdown/test/core/EngineDeterminism.spec.ts
+++ b/packages/cherry-markdown/test/core/EngineDeterminism.spec.ts
@@ -1,34 +1,72 @@
 /**
- * Regression test: two fresh engine instances must render the same document
- * to byte-identical HTML.
+ * Regression test: fresh Engine instances must render the same document to
+ * byte-identical HTML (cross-instance determinism).
  *
- * Motivation: paragraph-level cache key prefixes (~~C{n}) come from a
- * module-level counter shared across instances. On documents where a block's
- * hashed content still contains another hook's placeholder token, `data-sign`
- * ends up instance-dependent, so fresh instances produce slightly different
- * HTML (previously only stable within one instance).
+ * Root cause: paragraph cache key prefixes (`~~C{n}`) come from a module-level
+ * counter shared across instances, so different instances number their
+ * placeholders differently (`~~C2` vs `~~C16`). When a paragraph's markdown is
+ * hashed for `data-sign` while it still contains another hook's `~~C{n}`
+ * placeholder (e.g. an unterminated block-math region followed by an inline
+ * formula), the hash — and therefore the output `data-sign` — drifts per
+ * instance.
+ *
+ * Minimal trigger (verified): "$$\n行内公式： $e=mc^2$"
  */
 import CherryEngine from '../../src/index.engine.core';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-function richMarkdown() {
-  // 文档需同时包含段落级占位与行内公式，触发“hash 内容含另一 hook 占位符”路径
+const MINIMAL_TRIGGER = '$$\n行内公式： $e=mc^2$';
+
+function exampleMarkdown() {
   return readFileSync(resolve(process.cwd(), 'test/example.md'), 'utf8');
 }
 
+function plain(n) {
+  return Array.from({ length: n }, (_, i) => `P${i}: normal **bold ${i}** *em* and [link ${i}](https://e.com/${i}).`).join('\n\n');
+}
+
+// 一组覆盖常见语法形态的文档，用于通用确定性断言
+const corpus = [
+  MINIMAL_TRIGGER,
+  plain(8),
+  '<div data-x="1"><b>bold</b></div>\n\nplain *em* after html',
+  '| a | b |\n| - | - |\n| 1 | 2 |\n\nrow text',
+  '```js\nconst x = 1;\n```\n\npara after code',
+  '# Heading **b**\n\n- li1\n- li2\n\n> quote',
+];
+
+function render(md) {
+  return new CherryEngine().makeHtml(md);
+}
+
 describe('Engine cross-instance determinism', () => {
-  it('two fresh engines produce byte-identical HTML for the same document', () => {
-    const md = richMarkdown();
-    const htmlA = new CherryEngine().makeHtml(md);
-    const htmlB = new CherryEngine().makeHtml(md);
-    expect(htmlA).toBe(htmlB);
+  it('two fresh engines agree on the minimal trigger', () => {
+    expect(render(MINIMAL_TRIGGER)).toBe(render(MINIMAL_TRIGGER));
   });
 
-  it('three fresh engines all agree (stability)', () => {
-    const md = richMarkdown();
-    const outs = [new CherryEngine().makeHtml(md), new CherryEngine().makeHtml(md), new CherryEngine().makeHtml(md)];
-    expect(outs[1]).toBe(outs[0]);
-    expect(outs[2]).toBe(outs[0]);
+  it('two fresh engines agree on the rich example document', () => {
+    const md = exampleMarkdown();
+    expect(render(md)).toBe(render(md));
+  });
+
+  it('three fresh engines all agree across a markdown corpus', () => {
+    for (const md of corpus) {
+      const out = [render(md), render(md), render(md)];
+      expect(out[1]).toBe(out[0]);
+      expect(out[2]).toBe(out[0]);
+    }
+  });
+
+  it('creating more engines later does not change an existing engine output', () => {
+    const md = exampleMarkdown();
+    const e1 = new CherryEngine();
+    const first = e1.makeHtml(md);
+    const e2 = new CherryEngine();
+    e2.makeHtml(md);
+    const e3 = new CherryEngine();
+    e3.makeHtml(MINIMAL_TRIGGER);
+    // 全局计数器在构造 e2/e3 时被归零，不应影响已存在的 e1
+    expect(e1.makeHtml(md)).toBe(first);
   });
 });


### PR DESCRIPTION
# fix: 按实例重置段落缓存计数器，使全新 CherryEngine 实例渲染输出一致

> 分支：`fix/cherry-instance-determinism`（基于 dev，3 个 commit + changeset）
> 改动文件：`src/Engine.js`、`src/core/ParagraphBase.js`、`test/core/EngineDeterminism.spec.ts`

---

## 1. 问题

不同 `CherryEngine` 实例渲染**同一份富文档**会得到略有不同的 HTML：个别段落的 `data-sign` 不同（同实例内多次渲染稳定）。

**最小复现**（已从 example.md「## 公式」节剥离验证）：
```md
$$
行内公式： $e=mc^2$
```
```ts
const a = new CherryEngine().makeHtml(md); // 未闭合块级公式 + 行内公式
const b = new CherryEngine().makeHtml(md);
a === b; // false（个别 data-sign 不同；dev 复现，本修复后 true）
```

## 2. 影响面

- `data-sign` 是引擎内部属性（Previewer 增量 diff / data-lines 用），不进入对外文档语义；
- 单实例使用不受影响（实例内多次渲染稳定）；
- 受影响场景：**同一进程/页面存在多个引擎实例、SSR 多实例、跨实例输出对比/快照**——输出级不再逐字节一致。

## 3. 根因与代码路径

- `ParagraphBase` 段落缓存计数器 `cacheCounter` 是**模块级共享**并在构造每个需要缓存的段落 hook 时递增（`src/core/ParagraphBase.js`）；
- 于是不同引擎实例的段落占位符编号整体不同（实例 1：`~~C0..C13`，实例 2：`~~C14..C27`）；
- 触发路径：
  1. 行内公式 hook `InlineMath` 通过 `pushCache(result, IN_PARAGRAPH_CACHE_KEY_PREFIX + sign)` 把占位符写回段落 md（`src/core/hooks/InlineMath.js`，形如 `~~C{n}I!<sign>$`）；
  2. 未闭合块级公式后的段落再次被段落渲染器处理时，`Paragraph.makeHtml` 的 `processor` 对仍含该占位符的段落内容调用 `cacheAndGetData(p, sentenceMakeFunc, …)` → `$checkCache` → `engine.hash(p)`（`src/Engine.js` 的 `hash`）；
  3. `p` 里携带的 `~~C{n}` 中 `{n}` 随实例不同 → `data-sign` 随实例漂移。
- 修复：`ParagraphBase.resetCacheCounter()` + `Engine` 构造 HookCenter 前调用，让每个实例内建段落 hook 从 `~~C0` 按相同顺序编号 → 占位符/输出跨实例一致。不改变单实例行为与任何 hash 语义。

## 4. 修改

```diff
export default class ParagraphBase extends SyntaxBase {
   static IN_PARAGRAPH_CACHE_KEY_PREFIX = '!';
   static IN_PARAGRAPH_CACHE_KEY_PREFIX_REGEX = '\\!';
+  static resetCacheCounter() {
+    cacheCounter = 0;
+  }
```
```diff
   constructor(markdownParams, cherry) {
     this.initMath(markdownParams);
     this.$configInit(markdownParams);
+    ParagraphBase.resetCacheCounter();
     this.hookCenter = new HookCenter(hooksConfig, markdownParams, cherry);
```

## 5. 验证

回归测试 `test/core/EngineDeterminism.spec.ts`（4 用例）：
1. 最小复现文档：两个全新实例输出一致；
2. 富文档 `test/example.md`：两个全新实例输出一致；
3. corpus 确定性：纯文本/HTML/表格/代码/引用/标题等 6 类文档 × 3 实例两两一致；
4. 并存引擎：已存在的 e1 渲染后，再建 e2/e3（全局计数器被归零），e1 复渲输出不变。

- 红→绿：dev（去掉本修复）下该 spec **3 failed**，修复后 **4 passed**；
- 全量测试 **127 文件全部通过（0 失败）**（含既有快照，data-sign 语义未漂移）；
- 性能无回退（example.md ≈ dev 基线 ~111~116 ops/s）。

已知边界（诚实说明）：回归覆盖默认/内置 hook 路径与多实例并存；**自定义 `hooksConfig`（用户传入 hook 实例）** 的跨实例行为未在测试内显式覆盖（其索引由用户侧构造时机决定，属既有语义），如需纳入可作为后续补充。

## 6. 复测方式

```bash
cd packages/cherry-markdown
npx vitest run test/core/EngineDeterminism.spec.ts   # 4 passed
npx vitest run --exclude test/build/built-artifact-contract.spec.js   # 全量通过
```

