### PR TITLE
fix: correct nested list rendering after Tab indentation

### DIFF
--- a/.changeset/quiet-lists-indent.md
+++ b/.changeset/quiet-lists-indent.md
@@ -1,0 +1,6 @@
+---
+'cherry-markdown': patch
+'@cherry-markdown/miniprogram': patch
+---
+
+fix: preserve empty nested list markers after Tab indentation and avoid duplicate native Tab input in empty list prefixes.

--- a/packages/cherry-markdown/src/Cherry.js
+++ b/packages/cherry-markdown/src/Cherry.js
@@ -45,7 +45,6 @@ import Logger from '@/Logger';
 import { urlProcessorProxy } from './UrlCache';
 import { CherryStatic } from './CherryStatic';
 import { destroySearcherBridge, initSearcherBridge } from './toolbars/searcher/SearcherBridge';
-import { LIST_CONTENT } from '@/utils/regexp';
 
 /** @typedef {import('~types/cherry').CherryOptions} CherryOptions */
 /** @typedef {import('~types/editor').CM6Adapter} CM6AdapterType */
@@ -1086,30 +1085,6 @@ export default class Cherry extends CherryStatic {
    * @param {KeyboardEvent} evt
    */
   fireShortcutKey(evt) {
-    // 获取当前光标位置 - CodeMirror 6 API
-    const { view } = this.editor.editor;
-    const selection = view.state.selection.main;
-    const pos = selection.head;
-    const line = view.state.doc.lineAt(pos);
-    const lineContent = line.text;
-    const cursor = { line: line.number - 1, ch: pos - line.from };
-
-    // shift + tab 已经被绑定为缩进，所以这里不做处理
-    if (!evt.shiftKey && evt.key === 'Tab' && LIST_CONTENT.test(lineContent)) {
-      // 每按一次Tab，如果当前光标在行首或者行尾，就在行首加一个\t
-      if (cursor.ch === 0 || cursor.ch === lineContent.length || cursor.ch === lineContent.length + 1) {
-        evt.preventDefault();
-        // 使用 CodeMirror 6 API 替换整行内容
-        view.dispatch({
-          changes: {
-            from: line.from,
-            to: line.to,
-            insert: `\t${lineContent}`,
-          },
-          selection: { anchor: line.from + cursor.ch + 1 },
-        });
-      }
-    }
     if (this.toolbar.matchShortcutKey(evt)) {
       // 快捷键
       const needPreventDefault = this.toolbar.fireShortcutKey(evt);

--- a/packages/cherry-markdown/src/Editor.js
+++ b/packages/cherry-markdown/src/Editor.js
@@ -52,6 +52,7 @@ import { createElement } from './utils/dom';
 import { base64Reg, imgDrawioXmlReg, createUrlReg, getCodeBlockRule } from './utils/regexp';
 import { addEvent, removeEvent } from './utils/event';
 import { handleNewlineIndentList } from './utils/autoindent';
+import { allowListTabInput } from './utils/listTabInput';
 import diff from 'fast-diff';
 
 /**
@@ -2000,22 +2001,8 @@ export default class Editor {
       EditorState.changeFilter.of((tr) => {
         if (!tr.docChanged) return true;
 
-        // 某些浏览器/输入法组合会在 Tab 快捷键执行 indentMore 前，先向
-        // contenteditable 写入一个原生制表符。只过滤这类纯 Tab 的 input.type
-        // 事务，避免一次按键同时产生原生 Tab 和 CodeMirror 缩进。
-        if (tr.isUserEvent('input.type')) {
-          let hasInsertedTab = false;
-          let containsNonTabChange = false;
-          tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
-            const text = inserted.toString();
-            if (fromA !== toA || !/^\t+$/.test(text)) {
-              containsNonTabChange = true;
-            } else {
-              hasInsertedTab = true;
-            }
-          });
-          if (hasInsertedTab && !containsNonTabChange) return false;
-        }
+        // 仅在快捷键启用时过滤空列表前缀中的重复原生 Tab；保留代码和普通文本输入。
+        if (!this.shortcutDisabled && !allowListTabInput(tr)) return false;
 
         // 所有定义了atomic=true 的装饰器都被认为是原子装饰器，不允许局部修改和局部删除
         const marks = tr.startState.field(markField, false);

--- a/packages/cherry-markdown/src/Editor.js
+++ b/packages/cherry-markdown/src/Editor.js
@@ -2000,6 +2000,23 @@ export default class Editor {
       EditorState.changeFilter.of((tr) => {
         if (!tr.docChanged) return true;
 
+        // 某些浏览器/输入法组合会在 Tab 快捷键执行 indentMore 前，先向
+        // contenteditable 写入一个原生制表符。只过滤这类纯 Tab 的 input.type
+        // 事务，避免一次按键同时产生原生 Tab 和 CodeMirror 缩进。
+        if (tr.isUserEvent('input.type')) {
+          let hasInsertedTab = false;
+          let containsNonTabChange = false;
+          tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+            const text = inserted.toString();
+            if (fromA !== toA || !/^\t+$/.test(text)) {
+              containsNonTabChange = true;
+            } else {
+              hasInsertedTab = true;
+            }
+          });
+          if (hasInsertedTab && !containsNonTabChange) return false;
+        }
+
         // 所有定义了atomic=true 的装饰器都被认为是原子装饰器，不允许局部修改和局部删除
         const marks = tr.startState.field(markField, false);
         if (marks && marks !== Decoration.none) {

--- a/packages/cherry-markdown/src/core/hooks/List.js
+++ b/packages/cherry-markdown/src/core/hooks/List.js
@@ -255,7 +255,7 @@ export default class List extends ParagraphBase {
   rule() {
     const ret = {
       begin: '(?:^|\n)(\n*)(([ ]{0,3}([*+-]|\\d+[.]|en-[a-z]\\.|[a-z]\\.|[I一二三四五六七八九十]+\\.)[ \\t]+)',
-      content: '([^\\r]+?)',
+      content: '([^\\r]*?)',
       end: '(~0|\\n{2,}(?=\\S)(?![ \\t]*(?:[*+-]|\\d+[.]|en-[a-z]\\.|[a-z]\\.|[I一二三四五六七八九十]+\\.)[ \\t]+)))',
     };
     ret.reg = new RegExp(ret.begin + ret.content + ret.end, 'gm');

--- a/packages/cherry-markdown/src/utils/listTabInput.js
+++ b/packages/cherry-markdown/src/utils/listTabInput.js
@@ -1,0 +1,27 @@
+import { syntaxTree } from '@codemirror/language';
+
+/**
+ * Filter native Tab insertion in an empty Markdown list prefix before indentMore runs.
+ * Leave ordinary text, code, paste, replacement and programmatic transactions intact.
+ * @param {import('@codemirror/state').Transaction} tr
+ * @returns {boolean}
+ */
+export function allowListTabInput(tr) {
+  if (!tr.isUserEvent('input.type') || tr.isUserEvent('input.type.compose') || !tr.docChanged) return true;
+
+  let blocked = false;
+  let otherChange = false;
+  tr.changes.iterChanges((from, to, _fromB, _toB, inserted) => {
+    const line = tr.startState.doc.lineAt(from);
+    const marker = /^[ \t]*([*+-]|\d+[.)])[ \t]+$/.exec(line.text);
+    if (from !== to || inserted.toString() !== '\t' || !marker || from > line.from + line.text.search(/\S/)) {
+      otherChange = true;
+      return;
+    }
+    let node = syntaxTree(tr.startState).resolveInner(line.from + line.text.search(/\S/) + 1, -1);
+    while (node.parent && node.name !== 'ListItem') node = node.parent;
+    if (node.name === 'ListItem') blocked = true;
+    else otherChange = true;
+  });
+  return !blocked || otherChange;
+}

--- a/packages/cherry-markdown/test/codemirror/listTabInput.spec.ts
+++ b/packages/cherry-markdown/test/codemirror/listTabInput.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { EditorState } from '@codemirror/state';
+import { markdown } from '@codemirror/lang-markdown';
+import { indentMore } from '@codemirror/commands';
+import { allowListTabInput } from '../../src/utils/listTabInput';
+
+function stateFor(doc: string) {
+  return EditorState.create({
+    doc,
+    selection: { anchor: doc.length },
+    extensions: [markdown(), EditorState.changeFilter.of(allowListTabInput)],
+  });
+}
+
+describe('empty list native Tab input', () => {
+  it.each(['- ', '  - ', '1. ', '* ', '+ '])('filters duplicate native Tab before %j then indents once', (line) => {
+    const doc = `- Item 1\n    - Item 1.1\n- Item 2\n${line}`;
+    let state = stateFor(doc);
+    state = state.update({ changes: { from: state.doc.line(4).from, insert: '\t' }, userEvent: 'input.type' }).state;
+    expect(state.doc.toString()).toBe(doc);
+    indentMore({
+      state,
+      dispatch: (tr) => {
+        state = tr.state;
+      },
+    });
+    expect(state.doc.line(4).text).toBe(`  ${line}`);
+    state = state.update({ changes: { from: state.doc.length, insert: '12313' }, userEvent: 'input.type' }).state;
+    expect(state.doc.line(4).text).toBe(`  ${line}12313`);
+  });
+
+  it.each(['plain text', '- content', '```\n- \n```', '    - '])('preserves native tabs in %j', (doc) => {
+    const state = stateFor(doc);
+    const from = doc.indexOf('-') >= 0 ? doc.indexOf('-') : 0;
+    expect(state.update({ changes: { from, insert: '\t' }, userEvent: 'input.type' }).newDoc.toString()).toBe(
+      `${doc.slice(0, from)}\t${doc.slice(from)}`,
+    );
+  });
+
+  it.each(['input.paste', 'input.type.compose', 'api', undefined])('preserves %j transactions', (userEvent) => {
+    const state = stateFor('- ');
+    expect(state.update({ changes: { from: 0, insert: '\t' }, userEvent }).newDoc.toString()).toBe('\t- ');
+  });
+
+  it('preserves selection replacement and tabs after the marker', () => {
+    const state = stateFor('- ');
+    expect(state.update({ changes: { from: 0, to: 2, insert: '\t' }, userEvent: 'input.type' }).newDoc.toString()).toBe(
+      '\t',
+    );
+    expect(state.update({ changes: { from: 2, insert: '\t' }, userEvent: 'input.type' }).newDoc.toString()).toBe(
+      '- \t',
+    );
+  });
+});

--- a/packages/cherry-markdown/test/core/hooks/List.spec.ts
+++ b/packages/cherry-markdown/test/core/hooks/List.spec.ts
@@ -114,6 +114,39 @@ describe('core/hooks/list', () => {
     expect(container.querySelector('ul > li:last-child > ul > li > p')?.textContent).toBe('');
   });
 
+  it.each(['- ', '* ', '+ ', '1. '])(
+    'renders an empty marker %j without consuming the following paragraph',
+    (marker) => {
+      const container = document.createElement('div');
+      container.innerHTML = renderList(`${marker}\n\nparagraph`, { indentSpace: 2 });
+      expect(container.querySelectorAll('li')).toHaveLength(1);
+      expect(container.querySelector('li')?.textContent).not.toContain('paragraph');
+      expect(container.textContent).toContain('paragraph');
+    },
+  );
+
+  it.each([
+    '',
+    '\n\n',
+    'plain paragraph',
+    '- content',
+    '1. content',
+    '- parent\n  - child',
+    '- first\n\n- second',
+    '- content\n\nparagraph',
+    '- content\n\n# heading',
+    '- content\n\n> quote',
+    '- [ ] task',
+    '---',
+    '* * *',
+    '- parent\n  - child\n\nparagraph',
+  ])('preserves previous list matching for %j', (text) => {
+    const previous = createList({ indentSpace: 2 });
+    const rule = previous.rule();
+    previous.rule = () => ({ ...rule, reg: new RegExp(`${rule.begin}([^\\r]+?)${rule.end}`, 'gm') });
+    expect(renderList(text, { indentSpace: 2 })).toBe(previous.restoreCache(previous.makeHtml(text, sentenceMake)));
+  });
+
   it('returns no subtree HTML for a leaf and counts text without line endings', () => {
     const hook = createList({ indentSpace: 2 });
     hook.buildTree('- leaf', sentenceMake);

--- a/packages/cherry-markdown/test/core/hooks/List.spec.ts
+++ b/packages/cherry-markdown/test/core/hooks/List.spec.ts
@@ -105,6 +105,15 @@ describe('core/hooks/list', () => {
     expect(container.querySelector('ul > li > ol > li')?.textContent).toBe('ordered child');
   });
 
+  it('keeps an indented empty list item while the user is typing', () => {
+    const html = renderList('- Item 1\n    - Item 1.1\n- Item 2\n  - ', { indentSpace: 2 });
+    const container = document.createElement('div');
+    container.innerHTML = html;
+
+    expect(container.querySelectorAll(':scope > ul > li')).toHaveLength(2);
+    expect(container.querySelector('ul > li:last-child > ul > li > p')?.textContent).toBe('');
+  });
+
   it('returns no subtree HTML for a leaf and counts text without line endings', () => {
     const hook = createList({ indentSpace: 2 });
     hook.buildTree('- leaf', sentenceMake);


### PR DESCRIPTION
Pressing Enter after a list item and then Tab could produce both native Tab input and CodeMirror indentation, leaving the new item outside the expected nested list. Empty nested markers could also disappear until content was entered.

This change delegates indentation to CodeMirror and filters single native Tab insertions only before the marker of an empty, syntax-tree-confirmed list item while shortcuts are enabled. Ordinary text, code blocks, populated list items, composition, paste, replacements and API transactions remain unchanged. List matching now accepts an empty body so the child bullet is visible immediately.

Validation: 128 test files / 2235 tests passed, including real CodeMirror transaction sequences and old/new list matching comparisons; changed-file ESLint and diff checks passed. Physical-keyboard reproduction was confirmed for the original fix; the narrower filter is covered by transaction tests and still needs a fresh physical-keyboard check. Patch changesets cover cherry-markdown and the shared miniprogram renderer.

Fixes #1880
