### PR TITLE
fix: 修复mac下列表空项tab缩进失效的问题

### DIFF
--- a/.changeset/social-birds-swim.md
+++ b/.changeset/social-birds-swim.md
@@ -1,0 +1,5 @@
+---
+'cherry-markdown': patch
+---
+
+fix: 修复mac下列表空项tab缩进失效的问题

--- a/packages/cherry-markdown/src/Cherry.js
+++ b/packages/cherry-markdown/src/Cherry.js
@@ -1086,30 +1086,6 @@ export default class Cherry extends CherryStatic {
    * @param {KeyboardEvent} evt
    */
   fireShortcutKey(evt) {
-    // 获取当前光标位置 - CodeMirror 6 API
-    const { view } = this.editor.editor;
-    const selection = view.state.selection.main;
-    const pos = selection.head;
-    const line = view.state.doc.lineAt(pos);
-    const lineContent = line.text;
-    const cursor = { line: line.number - 1, ch: pos - line.from };
-
-    // shift + tab 已经被绑定为缩进，所以这里不做处理
-    if (!evt.shiftKey && evt.key === 'Tab' && LIST_CONTENT.test(lineContent)) {
-      // 每按一次Tab，如果当前光标在行首或者行尾，就在行首加一个\t
-      if (cursor.ch === 0 || cursor.ch === lineContent.length || cursor.ch === lineContent.length + 1) {
-        evt.preventDefault();
-        // 使用 CodeMirror 6 API 替换整行内容
-        view.dispatch({
-          changes: {
-            from: line.from,
-            to: line.to,
-            insert: `\t${lineContent}`,
-          },
-          selection: { anchor: line.from + cursor.ch + 1 },
-        });
-      }
-    }
     if (this.toolbar.matchShortcutKey(evt)) {
       // 快捷键
       const needPreventDefault = this.toolbar.fireShortcutKey(evt);

--- a/packages/cherry-markdown/src/Editor.js
+++ b/packages/cherry-markdown/src/Editor.js
@@ -42,7 +42,7 @@ import {
   selectLine,
 } from '@codemirror/commands';
 import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
-import { syntaxHighlighting, defaultHighlightStyle, foldGutter, indentOnInput } from '@codemirror/language';
+import { syntaxHighlighting, defaultHighlightStyle, foldGutter, indentOnInput, indentUnit } from '@codemirror/language';
 import htmlParser from '@/utils/htmlparser';
 import pasteHelper from '@/utils/pasteHelper';
 import Logger from '@/Logger';
@@ -2162,6 +2162,8 @@ export default class Editor {
           return false;
         },
       }),
+      // 设置缩进单位为2个空格
+      indentUnit.of('  '),
     ];
 
     const state = EditorState.create({

--- a/packages/cherry-markdown/src/core/hooks/List.js
+++ b/packages/cherry-markdown/src/core/hooks/List.js
@@ -255,7 +255,7 @@ export default class List extends ParagraphBase {
   rule() {
     const ret = {
       begin: '(?:^|\n)(\n*)(([ ]{0,3}([*+-]|\\d+[.]|en-[a-z]\\.|[a-z]\\.|[I一二三四五六七八九十]+\\.)[ \\t]+)',
-      content: '([^\\r]+?)',
+      content: '([^\\r]*?)',
       end: '(~0|\\n{2,}(?=\\S)(?![ \\t]*(?:[*+-]|\\d+[.]|en-[a-z]\\.|[a-z]\\.|[I一二三四五六七八九十]+\\.)[ \\t]+)))',
     };
     ret.reg = new RegExp(ret.begin + ret.content + ret.end, 'gm');

--- a/packages/cherry-markdown/src/core/hooks/List.js
+++ b/packages/cherry-markdown/src/core/hooks/List.js
@@ -256,7 +256,7 @@ export default class List extends ParagraphBase {
   rule() {
     const ret = {
       begin: '(?:^|\n)(\n*)(([ ]{0,3}([*+-]|\\d+[.]|en-[a-z]\\.|[a-z]\\.|[I一二三四五六七八九十]+\\.)[ \\t]+)',
-      content: '([^\\r]*?)',
+      content: '([^\\r]+?)',
       end: '(~0|\\n{2,}(?=\\S)(?![ \\t]*(?:[*+-]|\\d+[.]|en-[a-z]\\.|[a-z]\\.|[I一二三四五六七八九十]+\\.)[ \\t]+)))',
     };
     ret.reg = new RegExp(ret.begin + ret.content + ret.end, 'gm');

--- a/packages/cherry-markdown/src/core/hooks/List.js
+++ b/packages/cherry-markdown/src/core/hooks/List.js
@@ -41,7 +41,8 @@ export function makeChecklist(text) {
 // 缩进处理
 function handleIndent(str, node) {
   const indentRegex = /^(\t|[ ])/;
-  let $str = str;
+  // mac下按tab键会同时插入空格+\t，这种情况下直接去掉空格
+  let $str = str.replace(/^[ ]+(\t+)/, '$1');
   while (indentRegex.test($str)) {
     node.space += $str[0] === '\t' ? TAB_SPACE_NUM : 1;
     $str = $str.replace(indentRegex, '');


### PR DESCRIPTION
codemirror6 在mac下按 tab时会同时插入空格和\r，导致识别出错

- 删除已无用的代码（在列表语法里按tab时按整行缩进的逻辑已在codemirror6默认支持了）
- 在解析时兼容下同时有空格+\r 的情况